### PR TITLE
Allow _ab suffix in deep-inspect _meta.version (nightly N1)

### DIFF
--- a/deep-inspect-schema.test.ts
+++ b/deep-inspect-schema.test.ts
@@ -135,4 +135,76 @@ describe("deep-inspect JSON Schemas", () => {
   test("future schema accepts planned merge/source/provenance fields", () => {
     expectValid(futureValidate, futureShapeExample(), "future-shape example");
   });
+
+  test("current and future schemas accept nightly _ab versions", () => {
+    const abVersions = ["7.25_ab430", "7.25_ab433", "7.25_ab1", "7.25.1_ab99", "7.24_ab0"];
+    for (const version of abVersions) {
+      const data = {
+        _meta: {
+          version,
+          generatedAt: "2026-08-13T12:00:00.000Z",
+          crashPathsTested: [],
+          crashPathsSafe: [],
+          crashPathsCrashed: [],
+          completionStats: {
+            argsTotal: 1,
+            argsWithCompletion: 0,
+            argsFailed: 0,
+            argsTimedOut: 0,
+            argsBlankOnRetry: 0,
+          },
+        },
+        ip: { _type: "path" as const },
+      };
+      expectValid(currentValidate, data, `current ab ${version}`);
+      expectValid(futureValidate, data, `future ab ${version}`);
+    }
+    // unknown must still pass in both schemas
+    for (const version of ["unknown", "7.22", "7.22.1", "7.24rc4", "7.24beta2"]) {
+      const data = {
+        _meta: {
+          version,
+          generatedAt: "2026-08-13T12:00:00.000Z",
+          crashPathsTested: [],
+          crashPathsSafe: [],
+          crashPathsCrashed: [],
+          completionStats: {
+            argsTotal: 1,
+            argsWithCompletion: 0,
+            argsFailed: 0,
+            argsTimedOut: 0,
+            argsBlankOnRetry: 0,
+          },
+        },
+        ip: { _type: "path" as const },
+      };
+      expectValid(currentValidate, data, `current ${version}`);
+      expectValid(futureValidate, data, `future ${version}`);
+    }
+  });
+
+  test("current and future schemas reject malformed _ab versions", () => {
+    const bad = ["7.25_ab", "7.25_ab-1", "7.25_abX", "7.25__ab1", "nightly", "_ab430", "7.25ab430"];
+    for (const version of bad) {
+      const data = {
+        _meta: {
+          version,
+          generatedAt: "2026-08-13T12:00:00.000Z",
+          crashPathsTested: [],
+          crashPathsSafe: [],
+          crashPathsCrashed: [],
+          completionStats: {
+            argsTotal: 1,
+            argsWithCompletion: 0,
+            argsFailed: 0,
+            argsTimedOut: 0,
+            argsBlankOnRetry: 0,
+          },
+        },
+        ip: { _type: "path" as const },
+      };
+      expect(currentValidate(data)).toBe(false);
+      expect(futureValidate(data)).toBe(false);
+    }
+  });
 });

--- a/docs/deep-inspect.future.schema.json
+++ b/docs/deep-inspect.future.schema.json
@@ -30,7 +30,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "pattern": "^(unknown|\\d+\\.\\d+(?:\\.\\d+)?(?:(?:beta|rc)\\d+)?)$"
+          "pattern": "^(unknown|\\d+\\.\\d+(?:\\.\\d+)?(?:(?:beta|rc)\\d+)?(?:_ab\\d+)?)$"
         },
         "generatedAt": {
           "type": "string",

--- a/docs/deep-inspect.schema.json
+++ b/docs/deep-inspect.schema.json
@@ -31,7 +31,7 @@
         "version": {
           "type": "string",
           "description": "RouterOS version used to generate this artifact, or unknown for offline developer output.",
-          "pattern": "^(unknown|\\d+\\.\\d+(?:\\.\\d+)?(?:(?:beta|rc)\\d+)?)$"
+          "pattern": "^(unknown|\\d+\\.\\d+(?:\\.\\d+)?(?:(?:beta|rc)\\d+)?(?:_ab\\d+)?)$"
         },
         "generatedAt": {
           "type": "string",


### PR DESCRIPTION
## N1 — nightly single-slot pre-step

Smallest useful PR from #90 so a future `nightly` publish does not turn `bun test` red.

### What
- Extend `_meta.version` pattern in **both** deep-inspect schemas (`docs/deep-inspect.schema.json`, `docs/deep-inspect.future.schema.json`) to accept nightly builds like `7.25_ab430`:
  ```
  ^(unknown|\d+\.\d+(?:\.\d+)?(?:(?:beta|rc)\d+)?(?:_ab\d+)?)$
  ```
  Previous pattern rejected `_ab` (see probes in #90: `node -e "...test('7.25_ab430')" → false`).

- Add contract tests in `deep-inspect-schema.test.ts` that lock the new acceptance:
  - valid `ab` versions (`7.25_ab430`, `7.25_ab433`, `7.25.1_ab99`, …) pass in both schemas
  - malformed `ab` variants (`7.25_ab`, `nightly`, `7.25ab430`, …) are rejected
  - existing `unknown` / stable / `beta`/`rc` still pass

### Why N1 first
From #90 comment order (N1 ships alone, unblocks everything):

> No open questions blocking N1. Suggest N1 goes up as its own PR immediately — it's a 2-line schema change plus a test, and it's the thing standing between a nightly publish and a repo-wide red `bun test`.

Without this, any `docs/nightly/deep-inspect*.json` with `version: "7.25_abXXX"` fails `deep-inspect-schema.test.ts` (AJV `pattern`).

### Scope
- **Only** `_meta.version`. No `VERSION_RE` / `restraml-shared.js` / `build-docs-index.mjs` changes (that's N2). No nightly workflow, no `docs/nightly/` shape, no `openapi`/changelog UI (N4–N5).

### Verification
- `bun test` — 213 pass (6 in `deep-inspect-schema.test.ts`, including the two new cases)
- `bunx tsc --noEmit` — clean
- `bunx @biomejs/biome check` — clean for changed test file

Refs #90 (proposed order N1). Follows #90 viability notes: synthetic `nightly` name stays out of `_meta.version` — this only widens the real RouterOS version string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema validation now supports RouterOS version strings with optional numeric `_ab` build suffixes, such as `_ab1` or `_ab123`.
  * Existing supported version formats remain valid.

* **Bug Fixes**
  * Improved validation rejects malformed `_ab` version formats while accepting valid current and future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->