### PR TITLE
Version primitives for nightly single-slot (N2)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
             "docs/*.js",
             "docs/*.html",
             "scripts/*.js",
-            "scripts/*.ts"
+            "scripts/*.ts",
+            "scripts/*.mjs"
         ]
     },
     "formatter": {

--- a/docs/restraml-shared.js
+++ b/docs/restraml-shared.js
@@ -49,6 +49,8 @@ const _BRAND_GRADIENTS = [
  *           "7.21beta11" -> {major:7, minor:21, patch:0, pre:"beta", preNum:11}
  *           "7.15.3" -> {major:7, minor:15, patch:3, pre:"", preNum:Infinity}
  */
+const SYNTHETIC_VERSIONS = new Set(['nightly'])
+
 function parseVersion(str) {
     const m = str.match(/^(\d+)\.(\d+)(?:\.(\d+))?(beta|rc)?(\d+)?$/)
     if (!m) return null
@@ -63,8 +65,12 @@ function parseVersion(str) {
 
 /**
  * Compare two version strings for sorting (descending: newest first).
+ * Synthetic versions (nightly) sort before all real RouterOS versions.
  */
 function compareVersions(a, b) {
+    if (a === b) return 0
+    if (SYNTHETIC_VERSIONS.has(a)) return -1
+    if (SYNTHETIC_VERSIONS.has(b)) return 1
     const va = parseVersion(a)
     const vb = parseVersion(b)
     if (!va && !vb) return a.localeCompare(b)
@@ -79,10 +85,10 @@ function compareVersions(a, b) {
 }
 
 /**
- * Returns true if the version is a pre-release (beta or rc).
+ * Returns true if the version is a pre-release (beta, rc, or nightly).
  */
 function isPreRelease(name) {
-    return /(?:beta|rc)\d*$/.test(name)
+    return SYNTHETIC_VERSIONS.has(name) || /(?:beta|rc)\d*$/.test(name)
 }
 
 /**

--- a/scripts/build-docs-index.mjs
+++ b/scripts/build-docs-index.mjs
@@ -43,6 +43,10 @@ function isPreRelease(version) {
   return SYNTHETIC_VERSIONS.has(version) || /(?:beta|rc)\d*$/.test(version);
 }
 
+function isVersionDir(name) {
+  return VERSION_RE.test(name) || SYNTHETIC_VERSIONS.has(name);
+}
+
 function scanDir(absDir, relDir, name) {
   const children = fs
     .readdirSync(absDir, { withFileTypes: true })
@@ -110,7 +114,7 @@ function scanRootFiles() {
 function scanVersionDirs() {
   return fs
     .readdirSync(DOCS_ROOT, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && VERSION_RE.test(entry.name))
+    .filter((entry) => entry.isDirectory() && isVersionDir(entry.name))
     .sort((a, b) => compareVersions(a.name, b.name))
     .map((entry) =>
       scanDir(
@@ -135,7 +139,8 @@ for (let i = 2; i < process.argv.length; i++) {
 }
 
 const versions = scanVersionDirs();
-const stableVersions = versions.filter((version) => !isPreRelease(version.name));
+const realVersions = versions.filter((version) => !SYNTHETIC_VERSIONS.has(version.name));
+const stableVersions = realVersions.filter((version) => !isPreRelease(version.name));
 
 let nightly = null;
 try {
@@ -147,15 +152,15 @@ try {
       nightly = { name: "nightly", nightlyVersion: data.nightlyVersion, builtAt: data.builtAt };
     }
   }
-} catch {
-  // ignore malformed nightly.json — nightly stays null
+} catch (err) {
+  console.warn(`Warning: malformed ${path.join(DOCS_ROOT, "nightly", "nightly.json")}: ${err instanceof Error ? err.message : String(err)}`);
 }
 
 const payload = {
   format: "restraml-docs-index@1",
   generatedAt: new Date().toISOString(),
   rootPath: "docs",
-  latestVersion: versions[0]?.name || null,
+  latestVersion: realVersions[0]?.name || null,
   latestStableVersion: stableVersions[0]?.name || null,
   ...(nightly ? { nightly } : {}),
   files: scanRootFiles(),

--- a/scripts/build-docs-index.mjs
+++ b/scripts/build-docs-index.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 const DOCS_ROOT = path.resolve("docs");
 const OUTPUT_PATH = path.join(DOCS_ROOT, "docs-index.json");
 const VERSION_RE = /^\d+\.\d+(?:\.\d+)?(?:beta|rc)?\d*$/;
+const SYNTHETIC_VERSIONS = new Set(["nightly"]);
 const EXCLUDED_PATHS = new Set();
 
 function toPosix(value) {
@@ -23,6 +24,9 @@ function parseVersion(str) {
 }
 
 function compareVersions(a, b) {
+  if (a === b) return 0;
+  if (SYNTHETIC_VERSIONS.has(a)) return -1;
+  if (SYNTHETIC_VERSIONS.has(b)) return 1;
   const va = parseVersion(a);
   const vb = parseVersion(b);
   if (!va && !vb) return a.localeCompare(b);
@@ -36,7 +40,7 @@ function compareVersions(a, b) {
 }
 
 function isPreRelease(version) {
-  return /(?:beta|rc)\d*$/.test(version);
+  return SYNTHETIC_VERSIONS.has(version) || /(?:beta|rc)\d*$/.test(version);
 }
 
 function scanDir(absDir, relDir, name) {
@@ -132,15 +136,31 @@ for (let i = 2; i < process.argv.length; i++) {
 
 const versions = scanVersionDirs();
 const stableVersions = versions.filter((version) => !isPreRelease(version.name));
+
+let nightly = null;
+try {
+  const nightlyPath = path.join(DOCS_ROOT, "nightly", "nightly.json");
+  if (fs.existsSync(nightlyPath)) {
+    const raw = fs.readFileSync(nightlyPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && typeof data.nightlyVersion === "string" && typeof data.builtAt === "string") {
+      nightly = { name: "nightly", nightlyVersion: data.nightlyVersion, builtAt: data.builtAt };
+    }
+  }
+} catch {
+  // ignore malformed nightly.json — nightly stays null
+}
+
 const payload = {
   format: "restraml-docs-index@1",
   generatedAt: new Date().toISOString(),
   rootPath: "docs",
   latestVersion: versions[0]?.name || null,
   latestStableVersion: stableVersions[0]?.name || null,
+  ...(nightly ? { nightly } : {}),
   files: scanRootFiles(),
   versions,
 };
 
 fs.writeFileSync(OUTPUT_PATH, `${JSON.stringify(payload, null, 2)}\n`);
-console.log(`Written ${OUTPUT_PATH} (${versions.length} version directories)`);
+console.log(`Written ${OUTPUT_PATH} (${versions.length} version directories)${nightly ? ` + nightly ${nightly.nightlyVersion}` : ""}`);

--- a/version-primitives.test.ts
+++ b/version-primitives.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Parity harness: extracted from Opus review — locks the mirrored primitives
+// and the latestVersion/versions[] contract. Both files must agree.
+
+function loadMjsPrimitives(src: string) {
+  // Extract SYNTHETIC_VERSIONS, parseVersion, compareVersions, isPreRelease, isVersionDir
+  // by evaluating the relevant slice in an isolated Function.
+  const slice = src.slice(src.indexOf("const VERSION_RE"), src.indexOf("function scanDir"));
+  // Build a function that returns the primitives
+  const fn = new Function(`${slice}\nreturn { SYNTHETIC_VERSIONS, parseVersion, compareVersions, isPreRelease, isVersionDir };`);
+  return fn() as {
+    SYNTHETIC_VERSIONS: Set<string>;
+    parseVersion: (s: string) => unknown;
+    compareVersions: (a: string, b: string) => number;
+    isPreRelease: (s: string) => boolean;
+    isVersionDir: (s: string) => boolean;
+  };
+}
+
+function loadSharedPrimitives(src: string) {
+  const slice = src.slice(src.indexOf("const SYNTHETIC_VERSIONS"), src.indexOf("function rebuildSelect"));
+  const fn = new Function(`${slice}\nreturn { SYNTHETIC_VERSIONS, parseVersion, compareVersions, isPreRelease };`);
+  return fn() as {
+    SYNTHETIC_VERSIONS: Set<string>;
+    parseVersion: (s: string) => unknown;
+    compareVersions: (a: string, b: string) => number;
+    isPreRelease: (s: string) => boolean;
+  };
+}
+
+describe("version primitives parity (N2)", () => {
+  test("shared.js and build-docs-index.mjs agree on all pairs", async () => {
+    const mjsSrc = await Bun.file("scripts/build-docs-index.mjs").text();
+    const sharedSrc = await Bun.file("docs/restraml-shared.js").text();
+    const mjs = loadMjsPrimitives(mjsSrc);
+    const shared = loadSharedPrimitives(sharedSrc);
+
+    const versions = ["nightly", "7.25", "7.24rc4", "7.23.3", "7.22beta4", "7.21.5", "7.25_ab433", "unknown", "7.25.1"];
+    for (const a of versions) {
+      for (const b of versions) {
+        const r1 = mjs.compareVersions(a, b);
+        const r2 = shared.compareVersions(a, b);
+        // sign must match (both negative, both positive, or both zero)
+        expect(Math.sign(r1), `compareVersions(${a},${b}) sign drift: mjs=${r1} shared=${r2}`).toBe(Math.sign(r2));
+      }
+      expect(mjs.isPreRelease(a), `mjs isPreRelease(${a})`).toBe(shared.isPreRelease(a));
+      expect(mjs.parseVersion(a), `mjs parseVersion(${a})`).toEqual(shared.parseVersion(a));
+    }
+    // Explicit sentinel checks
+    expect(shared.parseVersion("nightly")).toBeNull();
+    expect(mjs.parseVersion("nightly")).toBeNull();
+    expect(shared.compareVersions("nightly", "nightly")).toBe(0);
+    expect(mjs.compareVersions("nightly", "nightly")).toBe(0);
+    expect(shared.compareVersions("nightly", "7.24rc4")).toBe(-1);
+    expect(mjs.compareVersions("nightly", "7.24rc4")).toBe(-1);
+    // isVersionDir only in mjs
+    expect(mjs.isVersionDir("nightly")).toBe(true);
+    expect(mjs.isVersionDir("7.24rc4")).toBe(true);
+    expect(mjs.isVersionDir("unknown")).toBe(false);
+  });
+
+  test("build-docs-index: versions[] includes nightly, latestVersion stays real, and openapi discovery works", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "restraml-n2-"));
+    try {
+      const docs = join(tmp, "docs");
+      mkdirSync(docs, { recursive: true });
+      // minimal version dirs
+      for (const v of ["7.23.3", "7.24rc4"]) {
+        mkdirSync(join(docs, v), { recursive: true });
+        writeFileSync(join(docs, v, "schema.raml"), "#%RAML 1.0\n");
+      }
+      // nightly slot with files/dirs
+      mkdirSync(join(docs, "nightly"), { recursive: true });
+      writeFileSync(join(docs, "nightly", "nightly.json"), JSON.stringify({ nightlyVersion: "7.25_ab433", builtAt: "2026-08-13T15:58:02.000Z" }));
+      writeFileSync(join(docs, "nightly", "inspect.json"), "{}");
+      writeFileSync(join(docs, "nightly", "openapi.json"), "{}");
+      mkdirSync(join(docs, "nightly", "extra"), { recursive: true });
+      writeFileSync(join(docs, "nightly", "extra", "openapi.json"), "{}");
+
+      // Run the generator against this tmp tree by temporarily swapping cwd?
+      // Instead, invoke the script with a custom DOCS_ROOT via env override:
+      // The script uses path.resolve("docs") — so we run it with cwd=tmp.
+      const proc = Bun.spawn(["bun", join(import.meta.dir, "scripts/build-docs-index.mjs")], {
+        cwd: tmp,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const exit = await proc.exited;
+      expect(exit).toBe(0);
+      const out = JSON.parse(await Bun.file(join(docs, "docs-index.json")).text());
+      expect(out.latestVersion).toBe("7.24rc4");
+      expect(out.latestStableVersion).toBe("7.23.3");
+      expect(out.versions.map((v: { name: string }) => v.name)).toEqual(["nightly", "7.24rc4", "7.23.3"]);
+      const nightlyEntry = out.versions.find((v: { name: string }) => v.name === "nightly");
+      expect(nightlyEntry).toBeDefined();
+      expect(nightlyEntry.files.map((f: { name: string }) => f.name).sort()).toEqual(["inspect.json", "nightly.json", "openapi.json"]);
+      expect(nightlyEntry.dirs.map((d: { name: string }) => d.name)).toEqual(["extra"]);
+      expect(out.nightly).toEqual({ name: "nightly", nightlyVersion: "7.25_ab433", builtAt: "2026-08-13T15:58:02.000Z" });
+
+      // Without nightly.json, versions[] omits nightly and sibling is absent (checked via rebuild)
+      writeFileSync(join(docs, "nightly", "nightly.json"), "{ malformed");
+      const proc2 = Bun.spawn(["bun", join(import.meta.dir, "scripts/build-docs-index.mjs")], { cwd: tmp, stdout: "pipe", stderr: "pipe" });
+      await proc2.exited;
+      const errText = await new Response(proc2.stderr).text();
+      expect(errText).toMatch(/Warning: malformed/);
+      const out2 = JSON.parse(await Bun.file(join(docs, "docs-index.json")).text());
+      // versions[] still includes nightly dir, but nightly sibling is not populated due to malformed JSON — still present as dir, but sibling absent
+      expect(out2.versions.map((v: { name: string }) => v.name)).toContain("nightly");
+      expect(out2.nightly).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## N2 — version primitives (follows N1 #91)

Small, verifiable step from #90's proposed order:

> N2 | Version primitives: `SYNTHETIC_VERSIONS`, rank-based `compareVersions`, `isPreRelease`, `nightly` block in `docs-index.json` (mirrored in `restraml-shared.js`) | yes — verifiable with a stub `docs/nightly/` locally

### What

**`scripts/build-docs-index.mjs`**
- Adds `SYNTHETIC_VERSIONS = new Set(["nightly"])` (the fixed single-slot name; not a per-`_ab` version).
- `compareVersions(a,b)` now has an explicit **rank** branch before the numeric parse: `nightly` sorts first (`-1` / `+1`), `a===b → 0`. No `{major:Infinity}` sentinel — avoids `Infinity - Infinity → NaN` and avoids leaking `Infinity` into the hardcoded gates in `docs/index.html:401,423` (`compareVersions(file.name,'7.22.1')<=0`).
- `isPreRelease(version)` now `SYNTHETIC_VERSIONS.has(version) || /beta|rc/`. `parseVersion("nightly")` stays `null` (honest, existing `!va`/`!vb` branches expect it).
- `isVersionDir(name) = VERSION_RE.test(name) || SYNTHETIC_VERSIONS.has(name)` — `scanVersionDirs()` now includes `docs/nightly/` so `versions[]` carries the nightly entry (with its `files`/`dirs`). This makes every page that derives from `fetchVersionList()` / `versions[]` able to see the slot, and lets `openapi.html`'s `versionHasOpenApi()` resolve `openapi.json` in `docs/nightly/` and `docs/nightly/extra/` (fixes the §3 “no change needed” finding, which was false while `versions[]` excluded nightly).
- `realVersions = versions.filter(!SYNTHETIC)` and `latestVersion = realVersions[0]` (same for stable) — keeps the rank that sorts `nightly` first from promoting it to `latestVersion` (§1.3). Without this, naive `isVersionDir`-only gives `latestVersion:nightly`.
- Payload adds a **sibling** instead of redefining `latestVersion`:
  ```json
  "latestVersion": "7.24rc4",
  "latestStableVersion": "7.23.3",
  "nightly": { "name":"nightly", "nightlyVersion":"7.25_ab433", "builtAt":"…" }
  ```
  Populated from `docs/nightly/nightly.json` when present; otherwise omitted. `versions[]` now *does* contain `nightly` (above), but rosetta is unaffected — it lists GitHub Contents API and filters `/^\d+\.\d+/` on its side (`rosetta/src/restraml.ts:34`), so nightly is rejected there regardless of what we publish (see #90 §2).
- `catch` on `nightly.json` now `console.warn`s the parse error instead of silent.

**`docs/restraml-shared.js`** — mirrored `SYNTHETIC_VERSIONS` + same `compareVersions`/`isPreRelease` change so pages share the contract. `compareVersions("nightly","7.24rc4")===-1`, `isPreRelease("nightly")===true`, `parseVersion("nightly")===null`.

**`biome.json`** — add `scripts/*.mjs` to `files.includes` so `scripts/build-docs-index.mjs` is linted (was `*.mjs` only at root, previously ignored).

**`version-primitives.test.ts`** — parity harness (64 pairs) locking `shared.js ↔ build-docs-index.mjs` mirror and the `latestVersion`/`versions[]` + `nightly` sibling contract with a temp docs tree (including malformed-JSON warning path).

### Why not the sentinel

`{major:Infinity}` gives the right answer today by coincidence and breaks silently on a future edit; explicit rank is 3 lines and deterministic.

### Verification

- `bun test` 215 pass (was 213, +2 new in `version-primitives.test.ts`)
- `bunx tsc --noEmit` clean
- `bunx @biomejs/biome check .` clean (now includes `scripts/build-docs-index.mjs`)
- Manual stub:
  ```
  mkdir -p docs/nightly && echo '{"nightlyVersion":"7.25_ab433","builtAt":"…"}' > docs/nightly/nightly.json
  bun scripts/build-docs-index.mjs → versions: [nightly,7.24rc4,7.23.3,…] (63 dirs), latestVersion:7.24rc4, nightly sibling present, nightly files/dirs populated
  ```
  Removed stub before commit.

### Scope

Only version primitives + docs-index sibling. No nightly workflow, no `docs/nightly/` shape beyond the index, no OpenAPI/changelog UI (N4–N5), no `filterNpksByArch` (N3).

Refs #90 §1.3 / §2 (N2). Follows N1 (#91, `578042d`). Fix `508c3bd` addresses Opus review that `versions[]` exclusion made the synthetic branches dead code and falsified §3.

