### PR TITLE
Harden nightly-build for per-phase gates (N3.5)

### DIFF
--- a/scripts/nightly-build.test.ts
+++ b/scripts/nightly-build.test.ts
@@ -134,6 +134,7 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
     expect(() => buildOutputSuffix("x86", "all", "deep-inspect.x86")).toThrow();
     expect(() => buildOutputSuffix("x86", "all", "foo.json")).toThrow();
     expect(() => buildOutputSuffix("x86", "all", "bad name")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "")).toThrow();
   });
 
   test("outs.find fix — phase suffix prevents collision when tmpDir holds two crawls", () => {
@@ -149,8 +150,24 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
     expect(outs.includes(expectedExtra)).toBe(true);
     // Old code: outs.find(f => f.startsWith("deep-inspect.")) → ambiguous (always picks first)
     expect(outs.find((f) => f.startsWith("deep-inspect."))).toBe("deep-inspect.nightly-quickchr-x86-base.json");
-    // New logic: select by expectedFile first
-    expect(outs.includes(expectedBase) ? expectedBase : outs.find((f) => f.startsWith(`deep-inspect.${baseSuffix}`))).toBe(expectedBase);
-    expect(outs.includes(expectedExtra) ? expectedExtra : outs.find((f) => f.startsWith(`deep-inspect.${extraSuffix}`))).toBe(expectedExtra);
+    // New logic: exact match only
+    expect(outs.includes(expectedBase) ? expectedBase : undefined).toBe(expectedBase);
+    expect(outs.includes(expectedExtra) ? expectedExtra : undefined).toBe(expectedExtra);
+  });
+
+  test("exact-match gate does not validate wrong phase when expected output missing", () => {
+    // Regression for coderabbit 3778267083: if extra output is absent but base
+    // output exists, the gate must not fall back to the base file.
+    const outsOnlyBase = ["deep-inspect.nightly-quickchr-x86-base.json", "nightly.json"];
+    const extraSuffix = buildOutputSuffix("x86", "extra");
+    const expectedExtra = `deep-inspect.${extraSuffix}.json`;
+    const deepFile = outsOnlyBase.includes(expectedExtra) ? expectedExtra : undefined;
+    expect(deepFile).toBeUndefined();
+    // And vice versa: only extra present, asking for base should miss
+    const outsOnlyExtra = ["deep-inspect.nightly-quickchr-x86.json", "nightly.json"];
+    const baseSuffix = buildOutputSuffix("x86", "base");
+    const expectedBase = `deep-inspect.${baseSuffix}.json`;
+    const deepFileBase = outsOnlyExtra.includes(expectedBase) ? expectedBase : undefined;
+    expect(deepFileBase).toBeUndefined();
   });
 });

--- a/scripts/nightly-build.test.ts
+++ b/scripts/nightly-build.test.ts
@@ -124,7 +124,16 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
     expect(buildOutputSuffix("arm64", "base")).toBe("nightly-quickchr-arm64-base");
     expect(buildOutputSuffix("arm64", "all")).toBe("nightly-quickchr-arm64");
     expect(buildOutputSuffix("x86", "base", "custom")).toBe("custom");
-    expect(buildOutputSuffix("x86", "extra", "deep-inspect.x86")).toBe("deep-inspect.x86");
+    expect(buildOutputSuffix("x86", "extra", "x86")).toBe("x86");
+  });
+
+  test("buildOutputSuffix rejects path traversal and confusing names", () => {
+    expect(() => buildOutputSuffix("x86", "all", "../evil")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "a/b")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "a\\b")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "deep-inspect.x86")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "foo.json")).toThrow();
+    expect(() => buildOutputSuffix("x86", "all", "bad name")).toThrow();
   });
 
   test("outs.find fix — phase suffix prevents collision when tmpDir holds two crawls", () => {

--- a/scripts/nightly-build.test.ts
+++ b/scripts/nightly-build.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from "bun:test";
-import { compareAb, filterNpksByArch, parseAb } from "./nightly-build.ts";
+import {
+  buildOutputSuffix,
+  compareAb,
+  filterNpksByArch,
+  getArgsTotalFloor,
+  getExpectedMinPackageCount,
+  getNpksForPhase,
+  parseAb,
+} from "./nightly-build.ts";
 
 const fixture = await Bun.file("fixtures/nightly-dirent-list.json").json() as {
   dirent_list: Array<{ file_name: string }>;
@@ -64,5 +72,76 @@ describe("filterNpksByArch (nightly duplicate gotcha)", () => {
     expect(parseAb("7.25.1_ab100")).not.toBeNull();
     expect(compareAb("7.25.1_ab99", "7.25_ab99")).toBeGreaterThan(0);
     expect(compareAb("7.25_ab100", "7.25_ab99")).toBeGreaterThan(0);
+  });
+});
+
+describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
+  test("getNpksForPhase splits base vs extra", () => {
+    const x86 = filterNpksByArch(allFiles, VER, "x86");
+    expect(x86).toHaveLength(5);
+    expect(getNpksForPhase(x86, "base")).toEqual(["routeros-x86-7.25_ab434.npk"]);
+    expect(getNpksForPhase(x86, "extra")).toHaveLength(5);
+    expect(getNpksForPhase(x86, "all")).toHaveLength(5);
+    expect(getNpksForPhase(x86, "all")).toEqual(x86);
+    const arm64 = filterNpksByArch(allFiles, VER, "arm64");
+    expect(getNpksForPhase(arm64, "base")).toEqual(["routeros-7.25_ab434-arm64.npk"]);
+    expect(getNpksForPhase(arm64, "extra")).toHaveLength(9);
+    expect(getNpksForPhase(arm64, "all")).toHaveLength(9);
+  });
+
+  test("getExpectedMinPackageCount is phase-aware", () => {
+    expect(getExpectedMinPackageCount("x86", "base")).toBe(1);
+    expect(getExpectedMinPackageCount("x86", "extra")).toBe(5);
+    expect(getExpectedMinPackageCount("x86", "all")).toBe(5);
+    expect(getExpectedMinPackageCount("arm64", "base")).toBe(1);
+    expect(getExpectedMinPackageCount("arm64", "extra")).toBe(9);
+    expect(getExpectedMinPackageCount("arm64", "all")).toBe(9);
+  });
+
+  test("getArgsTotalFloor is phase-aware — base low enough for 28079, extra high", () => {
+    // Stable 7.24rc4 base 28079 must pass base floor; extra 35656 must pass extra floor.
+    // Nightly ab431 full extra x86 33685 / arm64 34735 must pass extra floor.
+    expect(getArgsTotalFloor("x86", "base")).toBeLessThan(28079);
+    expect(getArgsTotalFloor("arm64", "base")).toBeLessThan(28079);
+    expect(getArgsTotalFloor("x86", "extra")).toBeGreaterThan(25000);
+    expect(getArgsTotalFloor("arm64", "extra")).toBeGreaterThan(26000);
+    // Extra floors are ~33k/34k as calibrated; base floors ~25k/26k.
+    expect(getArgsTotalFloor("x86", "base")).toBe(25000);
+    expect(getArgsTotalFloor("arm64", "base")).toBe(26000);
+    expect(getArgsTotalFloor("x86", "extra")).toBe(33000);
+    expect(getArgsTotalFloor("x86", "all")).toBe(33000);
+    expect(getArgsTotalFloor("arm64", "extra")).toBe(34000);
+    expect(getArgsTotalFloor("arm64", "all")).toBe(34000);
+    // The old phase-blind floor 33000 would have failed the base crawl:
+    expect(28079).toBeLessThan(33000);
+    expect(28079).toBeGreaterThan(getArgsTotalFloor("x86", "base"));
+  });
+
+  test("buildOutputSuffix is arch+phase aware and overridable", () => {
+    expect(buildOutputSuffix("x86", "all")).toBe("nightly-quickchr-x86");
+    expect(buildOutputSuffix("x86", "extra")).toBe("nightly-quickchr-x86");
+    expect(buildOutputSuffix("x86", "base")).toBe("nightly-quickchr-x86-base");
+    expect(buildOutputSuffix("arm64", "base")).toBe("nightly-quickchr-arm64-base");
+    expect(buildOutputSuffix("arm64", "all")).toBe("nightly-quickchr-arm64");
+    expect(buildOutputSuffix("x86", "base", "custom")).toBe("custom");
+    expect(buildOutputSuffix("x86", "extra", "deep-inspect.x86")).toBe("deep-inspect.x86");
+  });
+
+  test("outs.find fix — phase suffix prevents collision when tmpDir holds two crawls", () => {
+    // Simulates N4's one-boot/two-crawl tmpDir holding both files.
+    const outs = ["deep-inspect.nightly-quickchr-x86-base.json", "deep-inspect.nightly-quickchr-x86.json", "nightly.json"];
+    const baseSuffix = buildOutputSuffix("x86", "base");
+    const extraSuffix = buildOutputSuffix("x86", "extra");
+    const expectedBase = `deep-inspect.${baseSuffix}.json`;
+    const expectedExtra = `deep-inspect.${extraSuffix}.json`;
+    expect(expectedBase).toBe("deep-inspect.nightly-quickchr-x86-base.json");
+    expect(expectedExtra).toBe("deep-inspect.nightly-quickchr-x86.json");
+    expect(outs.includes(expectedBase)).toBe(true);
+    expect(outs.includes(expectedExtra)).toBe(true);
+    // Old code: outs.find(f => f.startsWith("deep-inspect.")) → ambiguous (always picks first)
+    expect(outs.find((f) => f.startsWith("deep-inspect."))).toBe("deep-inspect.nightly-quickchr-x86-base.json");
+    // New logic: select by expectedFile first
+    expect(outs.includes(expectedBase) ? expectedBase : outs.find((f) => f.startsWith(`deep-inspect.${baseSuffix}`))).toBe(expectedBase);
+    expect(outs.includes(expectedExtra) ? expectedExtra : outs.find((f) => f.startsWith(`deep-inspect.${extraSuffix}`))).toBe(expectedExtra);
   });
 });

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -237,7 +237,24 @@ export function getArgsTotalFloor(arch: Arch, phase: Phase): number {
 }
 
 export function buildOutputSuffix(arch: Arch, phase: Phase, customSuffix?: string): string {
-  if (customSuffix) return customSuffix;
+  if (customSuffix) {
+    // Validate user-controlled suffix before it reaches deep-inspect.ts
+    // (which interpolates it into deep-inspect.<suffix>.json). Reject path
+    // traversal and confusing double-prefix names.
+    if (customSuffix.includes("/") || customSuffix.includes("\\") || customSuffix.includes("..")) {
+      fail(`--output-suffix must not contain path separators or ".." (got "${customSuffix}")`);
+    }
+    if (customSuffix.endsWith(".json")) {
+      fail(`--output-suffix must not include ".json" (got "${customSuffix}") — suffix is the part after "deep-inspect."`);
+    }
+    if (customSuffix.startsWith("deep-inspect.")) {
+      fail(`--output-suffix must not include "deep-inspect." prefix (got "${customSuffix}") — use the part after "deep-inspect." (e.g. "x86")`);
+    }
+    if (!/^[A-Za-z0-9._-]+$/.test(customSuffix)) {
+      fail(`--output-suffix must be a simple name ([A-Za-z0-9._-], got "${customSuffix}")`);
+    }
+    return customSuffix;
+  }
   const base = `nightly-quickchr-${arch}`;
   if (phase !== "all" && phase !== "extra") return `${base}-${phase}`;
   // extra and all both mean full set — keep suffix stable (no -extra) so existing

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -237,7 +237,7 @@ export function getArgsTotalFloor(arch: Arch, phase: Phase): number {
 }
 
 export function buildOutputSuffix(arch: Arch, phase: Phase, customSuffix?: string): string {
-  if (customSuffix) {
+  if (customSuffix !== undefined) {
     // Validate user-controlled suffix before it reaches deep-inspect.ts
     // (which interpolates it into deep-inspect.<suffix>.json). Reject path
     // traversal and confusing double-prefix names.
@@ -714,7 +714,7 @@ async function main() {
         // Phase-aware so base crawl (28k) does not fail the extra floor (33k).
         try {
           const expectedFile = `deep-inspect.${outputSuffix}.json`;
-          const deepFile = outs.includes(expectedFile) ? expectedFile : outs.find((f) => f === expectedFile || f.startsWith(`deep-inspect.${outputSuffix}`)) ?? outs.find((f) => f.startsWith("deep-inspect."));
+          const deepFile = outs.includes(expectedFile) ? expectedFile : undefined;
           if (deepFile) {
             const deepData = JSON.parse(await Bun.file(join(tmpDir, deepFile)).text()) as { _meta?: { completionStats?: { argsTotal?: number } } };
             const argsTotal = deepData._meta?.completionStats?.argsTotal ?? 0;

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -75,10 +75,13 @@ function fail(msg: string): never {
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
+export type Phase = "base" | "extra" | "all";
+
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
   options: {
     arch: { type: "string", default: "x86" },
+    phase: { type: "string", default: "all" },
     "base-version": { type: "string" },
     channel: { type: "string", default: "stable" },
     "keep-running": { type: "boolean", default: false },
@@ -86,6 +89,7 @@ const { values } = parseArgs({
     "skip-crawl": { type: "boolean", default: false },
     "skip-deep-inspect": { type: "boolean", default: false },
     "output-dir": { type: "string" },
+    "output-suffix": { type: "string" },
     "machine-name": { type: "string" },
     "dry-run": { type: "boolean", default: false },
     help: { type: "boolean", default: false },
@@ -105,6 +109,10 @@ Usage:
 Options:
   --arch <x86|arm64>        Target architecture (default: x86). arm64 on Intel
                             uses TCG (slow emulation) — pair with --skip-collect.
+  --phase <base|extra|all>  Which package set to install (default: all).
+                            base  → routeros-* only (routeros-only tree)
+                            extra → full nightly NPK set (all packages)
+                            all   → full set (alias for extra; default)
   --channel <name>          Base channel to boot before upgrade (default: stable).
                             Pinned to stable for nightly promotion; overridden by
                             --base-version.
@@ -115,6 +123,8 @@ Options:
                             --skip-deep-inspect. Recommended for arm64/TCG.
   --output-dir <dir>        Where to write deep-inspect outputs when not skipped
                             (default: mkdtemp nightly-quickchr-<ver>-<arch>-XXXXXX, or --output-dir to reuse).
+  --output-suffix <str>     Override deep-inspect output suffix (default:
+                            nightly-quickchr-<arch>[-<phase>]).
   --machine-name <name>     Override quickchr machine name (default:
                             restraml-nightly-quickchr-<arch>).
   --keep-running            Leave CHR running after the run (for manual inspection).
@@ -123,6 +133,7 @@ Options:
 
 Examples:
   bun scripts/nightly-build.ts --arch x86
+  bun scripts/nightly-build.ts --arch x86 --phase base
   bun scripts/nightly-build.ts --arch arm64 --skip-collect
   bun scripts/nightly-build.ts --arch arm64 --skip-collect --keep-running
 `.trim(),
@@ -134,6 +145,12 @@ const ARCH = (() => {
   const raw = (values.arch as string) ?? "x86";
   if (raw !== "x86" && raw !== "arm64") fail(`--arch must be x86 or arm64; got "${raw}"`);
   return raw as Arch;
+})();
+
+const PHASE = (() => {
+  const raw = (values.phase as string) ?? "all";
+  if (raw !== "base" && raw !== "extra" && raw !== "all") fail(`--phase must be base, extra, or all; got "${raw}"`);
+  return raw as Phase;
 })();
 
 const BASE_VERSION: string | undefined = values["base-version"] as string | undefined;
@@ -194,6 +211,39 @@ export function compareAb(a: string, b: string): number {
   if (pa[1] !== pb[1]) return pa[1] - pb[1];
   if (pa[2] !== pb[2]) return pa[2] - pb[2];
   return pa[3] - pb[3];
+}
+
+export function getNpksForPhase(allArchNpks: string[], phase: Phase): string[] {
+  // base → routeros-* only (1 NPK); extra/all → full arch set (5 or 9)
+  // For N4's one-boot/two-crawls, N4 will call base then extra against the same
+  // CHR via two workflow steps; isolated extra=all (full set) remains valid as a
+  // standalone full upgrade, while phase-aware floors keep base from failing.
+  if (phase === "base") return allArchNpks.filter((f) => f.toLowerCase().startsWith("routeros-"));
+  return allArchNpks;
+}
+
+export function getExpectedMinPackageCount(arch: Arch, phase: Phase): number {
+  if (phase === "base") return 1;
+  return arch === "arm64" ? 9 : 5;
+}
+
+export function getArgsTotalFloor(arch: Arch, phase: Phase): number {
+  // Calibrated from stable 7.24rc4 (base 28079 vs extra 35656) and nightly ab431
+  // full extra (x86 33685, arm64 34735). Base tree is ~7–8k smaller than extra.
+  // Floors are deliberately low (not near median) to avoid flaking on minor
+  // RouterOS churn while still catching a truncated crawl.
+  if (phase === "base") return arch === "arm64" ? 26000 : 25000;
+  return arch === "arm64" ? 34000 : 33000;
+}
+
+export function buildOutputSuffix(arch: Arch, phase: Phase, customSuffix?: string): string {
+  if (customSuffix) return customSuffix;
+  const base = `nightly-quickchr-${arch}`;
+  if (phase !== "all" && phase !== "extra") return `${base}-${phase}`;
+  // extra and all both mean full set — keep suffix stable (no -extra) so existing
+  // single-crawl consumers keep the same file names; N4 can pass explicit
+  // --output-suffix when it needs distinct base vs extra files in one tmpDir.
+  return base;
 }
 
 async function discoverNightly(arch: Arch): Promise<{ version: string; files: string[]; allFiles: string[]; token: string; resolvedFrom: "302" | "pinned"; dirents: Array<{ file_name: string; size?: number; last_modified?: string }>; npks: Array<{ file: string; size: number | null; lastModified: string | null }>; rejected: string[]; buildWindow: { earliest: string; latest: string } | null }> {
@@ -279,6 +329,9 @@ async function downloadNpks(files: string[], dir: string, token: string) {
 
 async function main() {
   const { version: nightlyVer, files: archFiles, token: nightlyToken, resolvedFrom: nightlyResolvedFrom, dirents: nightlyDirents, npks: nightlyNpks, rejected: nightlyRejected, buildWindow: nightlyBuildWindow } = await discoverNightly(ARCH);
+  const phaseFiles = getNpksForPhase(archFiles, PHASE);
+  const outputSuffix = buildOutputSuffix(ARCH, PHASE, values["output-suffix"] as string | undefined);
+  if (phaseFiles.length === 0) fail(`no ${ARCH} NPKs for phase ${PHASE} (arch filter yielded ${archFiles.length} before phase filter)`);
   const tmpDir = (() => {
     const custom = values["output-dir"] as string | undefined;
     if (custom) {
@@ -289,9 +342,10 @@ async function main() {
   })();
 
   if (values["dry-run"]) {
-    log(`\n--dry-run: would download ${archFiles.length} ${ARCH} NPK(s) for ${nightlyVer} to ${join(tmpDir, "npks")}`);
-    for (const f of archFiles) log(`  ${f}`);
-    log(`\n✓ dry-run done — no CHR started (arch=${ARCH} ${IS_CROSS_ARCH ? "[cross-arch TCG on x64]" : "[native]"})`);
+    log(`\n--dry-run: would download ${phaseFiles.length} ${ARCH} NPK(s) for ${nightlyVer} [phase=${PHASE}, suffix=${outputSuffix}] to ${join(tmpDir, "npks")}`);
+    for (const f of phaseFiles) log(`  ${f}`);
+    if (PHASE !== "all") log(`  (all for ${ARCH}: ${archFiles.join(", ")})`);
+    log(`\n✓ dry-run done — no CHR started (arch=${ARCH} phase=${PHASE} ${IS_CROSS_ARCH ? "[cross-arch TCG on x64]" : "[native]"})`);
     return;
   }
 
@@ -325,7 +379,7 @@ async function main() {
     }
   }
 
-  await downloadNpks(archFiles, join(tmpDir, "npks"), nightlyToken);
+  await downloadNpks(phaseFiles, join(tmpDir, "npks"), nightlyToken);
 
   // ── boot stable CHR via quickchr — pinned to stable (the nightly.yaml shape) ──
   // Fresh instance every run; the inspect crawl is the slow part, not bring-up.
@@ -371,8 +425,8 @@ async function main() {
 
     // ── upload nightly NPKs via quickchr SCP ──
     const npkDir = join(tmpDir, "npks");
-    const npkPaths = archFiles.map((f) => join(npkDir, f));
-    log(`\n→ uploading ${npkPaths.length} ${ARCH} NPK(s) via instance.upload (SCP)`);
+    const npkPaths = phaseFiles.map((f) => join(npkDir, f));
+    log(`\n→ uploading ${npkPaths.length} ${ARCH} NPK(s) [phase=${PHASE}] via instance.upload (SCP)`);
     for (const p of npkPaths) {
       log(`  · ${p}`);
       await chr.upload(p);
@@ -457,12 +511,12 @@ async function main() {
         postPkgNames = list.map((p) => p.name ?? "?");
         log(`  post-upgrade packages: ${postPkgCount} names=${postPkgNames.join(", ")}`);
         for (const p of list) if (p.version) log(`    ${p.name} ${p.version} build-time=${p["build-time"] ?? "?"}`);
-        const expectedMin = ARCH === "arm64" ? 9 : 5;
-        if (postPkgCount < expectedMin) fail(`Package count ${postPkgCount} < expected ${expectedMin} for ${ARCH} — extra-package set incomplete after upgrade`);
-        else log(`  ✓ package count ${postPkgCount} ≥ ${expectedMin} for ${ARCH}`);
-        if (postPkgNames.length !== archFiles.length) {
+        const expectedMin = getExpectedMinPackageCount(ARCH, PHASE);
+        if (postPkgCount < expectedMin) fail(`Package count ${postPkgCount} < expected ${expectedMin} for ${ARCH} phase ${PHASE} — package set incomplete after upgrade`);
+        else log(`  ✓ package count ${postPkgCount} ≥ ${expectedMin} for ${ARCH} phase ${PHASE}`);
+        if (postPkgNames.length !== phaseFiles.length) {
           // Warn-only: version mismatch already fails the run, but this makes a bad filter diagnosable
-          log(`  ⚠ uploaded ${archFiles.length} NPKs but RouterOS reports ${postPkgCount} packages — possible duplicate/filter mismatch`);
+          log(`  ⚠ uploaded ${phaseFiles.length} NPKs but RouterOS reports ${postPkgCount} packages — possible duplicate/filter mismatch`);
         }
       } else log(`  packages raw=${JSON.stringify(pkgs).slice(0, 800)}`);
     } catch (e) {
@@ -494,6 +548,7 @@ async function main() {
     nightlyProvenance = {
       nightlyVersion: nightlyVer,
       arch: ARCH,
+      phase: PHASE,
       baseVersion: preVer,
       postVersion: postVer ?? null,
       machineName: MACHINE_NAME,
@@ -505,6 +560,8 @@ async function main() {
       hostArch: process.arch,
       crossArchTcg: IS_CROSS_ARCH,
       skipCollect: SKIP_COLLECT,
+      phaseFiles,
+      outputSuffix,
       source: {
         shortUrl: MT_LV_URL,
         token: nightlyToken,
@@ -514,8 +571,10 @@ async function main() {
       buildWindow: nightlyBuildWindow,
       packages: {
         arch: ARCH,
-        count: nightlyNpks.length,
-        npks: nightlyNpks,
+        phase: PHASE,
+        count: phaseFiles.length,
+        npks: phaseFiles.map((f) => nightlyNpks.find((n) => n.file === f) ?? { file: f, size: null as number | null, lastModified: null as string | null }),
+        allArchCount: nightlyNpks.length,
         rejected: nightlyRejected,
       },
     };
@@ -602,13 +661,13 @@ async function main() {
         "--transport",
         "rest",
         "--output-suffix",
-        `nightly-quickchr-${ARCH}`,
+        outputSuffix,
         "--output-dir",
         tmpDir,
         "--ros-version",
         nightlyVer,
       ];
-      log(`  bun ${deepArgs.join(" ")}`);
+      log(`  bun ${deepArgs.join(" ")} [phase=${PHASE}]`);
       const repoRootDeep = REPO_ROOT;
       const proc = Bun.spawn(["bun", ...deepArgs], {
         cwd: repoRootDeep,
@@ -635,17 +694,21 @@ async function main() {
           }
         }
         // Hard gate: deep-inspect argsTotal floor (catches green exit but truncated tree)
+        // Phase-aware so base crawl (28k) does not fail the extra floor (33k).
         try {
-          const deepFile = outs.find((f) => f.startsWith("deep-inspect."));
+          const expectedFile = `deep-inspect.${outputSuffix}.json`;
+          const deepFile = outs.includes(expectedFile) ? expectedFile : outs.find((f) => f === expectedFile || f.startsWith(`deep-inspect.${outputSuffix}`)) ?? outs.find((f) => f.startsWith("deep-inspect."));
           if (deepFile) {
             const deepData = JSON.parse(await Bun.file(join(tmpDir, deepFile)).text()) as { _meta?: { completionStats?: { argsTotal?: number } } };
             const argsTotal = deepData._meta?.completionStats?.argsTotal ?? 0;
-            const floor = ARCH === "arm64" ? 34000 : 33000;
-            if (argsTotal < floor) fail(`deep-inspect argsTotal ${argsTotal} < floor ${floor} for ${ARCH} — tree may be truncated`);
-            else log(`  ✓ deep-inspect argsTotal ${argsTotal} ≥ floor ${floor}`);
+            const floor = getArgsTotalFloor(ARCH, PHASE);
+            if (argsTotal < floor) fail(`deep-inspect argsTotal ${argsTotal} < floor ${floor} for ${ARCH} phase ${PHASE} (${deepFile}) — tree may be truncated`);
+            else log(`  ✓ deep-inspect argsTotal ${argsTotal} ≥ floor ${floor} for ${ARCH} phase ${PHASE} (${deepFile})`);
             if (rootChildCount > 0 && argsTotal < rootChildCount * 10) {
               log(`  ⚠ argsTotal ${argsTotal} is low relative to root children ${rootChildCount}`);
             }
+          } else {
+            log(`  ⚠ no deep-inspect output found (expected ${expectedFile})`);
           }
         } catch (e) {
           if (e instanceof Error && e.message.includes("deep-inspect argsTotal")) throw e;


### PR DESCRIPTION
## Summary

N3.5 — fixes the three forward hazards carried from #93 so **N4's `nightly.yaml` does not fail its first base crawl**. Ships alone, no workflow yet.

```
N1 578042d  #91 — deep-inspect schema _ab          DONE
N2 80fa3be  #92 — VERSION_RE / SYNTHETIC_VERSIONS  DONE
N3 626d3bd  #93 — nightly-build.ts                  DONE
N3.5 this  — per-phase gates + outs.find fix       ← NEW (unblocks N4)
N4 — nightly.yaml (discover gate → x86+arm64, 1 boot / 2 crawls each) — next
```

### Forward hazards fixed (from #93 re-review)

**1. `argsTotal` floor was phase-blind — would fail base crawl**
`floor = arch==arm64?34000:33000` is calibrated for the full-package set, but stable `7.24rc4` is `base 28,079` vs `extra 35,656`. Nightly `ab431` full extra is `x86 33,685 / arm64 34,735` — base would be ~28k and `28k < 33k` → fail.

Fix: `getArgsTotalFloor(arch, phase)` → `base 25k/26k`, `extra/all 33k/34k`. Floors are deliberately conservative (not near median) — calibrated from the numbers above. The old floor failing `28,079` is now covered by a test.

**2. `outs.find(f => f.startsWith("deep-inspect."))` was ambiguous**
With N4's `one boot / two crawls` the tmpDir will hold both `deep-inspect.nightly-quickchr-x86-base.json` and `deep-inspect.nightly-quickchr-x86.json`; first readdir match would silently gate the wrong file.

Fix: `buildOutputSuffix(arch, phase, custom?)` → `nightly-quickchr-x86` for `all/extra`, `nightly-quickchr-x86-base` for `base` (custom suffix overrides). Gate now selects `expectedFile = deep-inspect.<outputSuffix>.json` first, with fallback to prefix → generic. Adds a collision test showing old code always picking base.

**3. No `--phase` — script always uploaded full NPK set + single crawl**
N4 needs `routeros-* → base` then `remaining → extra/` (1 boot / 2 crawls, #90 §6). Extra phase without `routeros-*` alone would leave mixed versions, so `extra` / `all` both mean full set (5 x86 / 9 arm64) while `base` means `routeros-*` only (1 NPK).

Fix: `--phase base|extra|all` (default `all`) + `--output-suffix <str>` override. `getNpksForPhase()` handles the split, `getExpectedMinPackageCount()` makes the package-count gate phase-aware (`1` vs `5/9`), download/upload/logs/provenance all respect `PHASE`.

### Other wiring

* `nightly.json` provenance records `phase`, `phaseFiles`, `outputSuffix`; `packages` now has `phase`, `count` (phase count), `allArchCount`, `rejected` narrow (still 1 plausible generic duplicate).
* `--dry-run` now shows `[phase=..., suffix=...]` and lists `all for arch:` when filtered.
* `tmpDir` still per-run; distinct suffixes let base+extra coexist in one dir when N4 does sequential crawls (or N4 can pass explicit `--output-suffix x86-base` / `x86`).

### Tests & gates

* 11 nightly tests (was 6) — new `phase-aware helpers` describe block covers `getNpksForPhase`, `getExpectedMinPackageCount`, `getArgsTotalFloor` (including the `28,079 < 33,000` base-fail case), `buildOutputSuffix`, and the `outs.find` collision.
* `bun test` 226 pass (was 221), `tsc --noEmit` 0, `biome check` 0. No `inspect.json` shape change.

### Provenance shape delta for N4

N4 will aggregate `x86 base`, `x86 extra`, `arm64 base`, `arm64 extra` into the single `docs/nightly/` slot per #90 §6 (base `inspect.json` is x86 routeros-only, `extra/` is full). This PR gives it the primitives (`--phase`, per-phase floors, suffix) to do so without a second CHR boot per arch if desired; a two-boot first version (base job + extra job) also works since floors are now correct.

Closes the N3→N4 gap noted in #90#5284814141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phase-aware nightly upgrades with `base`, `extra`, and `all` package options.
  * Added `--phase` and `--output-suffix` command-line options.
  * Added validation for custom output suffixes to prevent unsafe or conflicting filenames.
  * Updated package selection, uploads, dry-run output, provenance, and inspection results to reflect the selected phase.
* **Bug Fixes**
  * Improved output-file selection to avoid filename collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->