### PR TITLE
Add nightly single-slot workflow (N4) (#90)

### DIFF
--- a/.github/actions/publish-with-retry/action.yml
+++ b/.github/actions/publish-with-retry/action.yml
@@ -64,7 +64,14 @@ runs:
         # concurrent workflows added to that directory between the checkout and
         # the push (e.g. app.json / routeros-app-yaml-schema.json published by the
         # /app YAML schemas workflow while the base schema workflow was running).
-        mapfile -t STAGED_FILES < <(git diff --cached --name-only)
+        # Split by kind: deletions cannot be replayed with `git restore
+        # --source=LOCAL_COMMIT` (they do not exist in that commit, so git aborts
+        # with "pathspec did not match").  A publish that replaces a whole
+        # directory — the nightly single slot — legitimately drops files between
+        # runs, so both kinds have to survive a retry.
+        mapfile -t STAGED_PRESENT < <(git diff --cached --name-only --diff-filter=d)
+        mapfile -t STAGED_DELETED < <(git diff --cached --name-only --diff-filter=D)
+        echo "Staged: ${#STAGED_PRESENT[@]} added/modified, ${#STAGED_DELETED[@]} deleted"
 
         git commit -m "$COMMIT_MESSAGE"
         LOCAL_COMMIT=$(git rev-parse HEAD)
@@ -89,16 +96,29 @@ runs:
           # Restore only the specific files that were staged, not entire directories.
           # Using per-file restore prevents accidentally deleting files added by other
           # concurrent workflows to the same directory.
-          git restore --source="$LOCAL_COMMIT" --worktree --staged -- "${STAGED_FILES[@]}" || {
-            echo "::error::git restore failed for $LOCAL_COMMIT"
-            exit 1
-          }
+          if [ "${#STAGED_PRESENT[@]}" -gt 0 ]; then
+            git restore --source="$LOCAL_COMMIT" --worktree --staged -- "${STAGED_PRESENT[@]}" || {
+              echo "::error::git restore failed for $LOCAL_COMMIT"
+              exit 1
+            }
+          fi
+          # Re-apply removals. --ignore-unmatch: a concurrent workflow may have
+          # deleted the same file already, which is not an error for us.
+          if [ "${#STAGED_DELETED[@]}" -gt 0 ]; then
+            git rm -q -f --ignore-unmatch -- "${STAGED_DELETED[@]}" || {
+              echo "::error::git rm failed while re-applying deletions"
+              exit 1
+            }
+          fi
           if ! run_docs_index; then
             echo "::error::docs:index failed on retry attempt $attempt"
             exit 1
           fi
 
-          git add "${STAGED_FILES[@]}" docs/docs-index.json
+          # Only re-add paths that exist; deletions were already staged by git rm
+          # above, and `git add` on a path that is gone from both worktree and
+          # index fails with "pathspec did not match".
+          git add "${STAGED_PRESENT[@]}" docs/docs-index.json
           if git diff --cached --quiet; then
             echo "Remote already contains the publish changes after syncing."
             exit 0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,6 +35,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   discover:
     name: Discover nightly
@@ -338,6 +341,9 @@ jobs:
           echo "Assembling docs/nightly/ for $NIGHTLY_VER"
 
           # Base tree is canonical x86 base (routeros-only) — maps to docs/nightly/
+          # Clear the overwritten single-slot so a previous app.json (or other file)
+          # does not survive when a later run skips producing it.
+          rm -rf docs/nightly
           mkdir -p docs/nightly/extra
 
           # Base (x86)

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,500 @@
+name: "Nightly Build"
+
+# Single overwritten slot docs/nightly/ for the mt.lv/nightly-build (ab) train.
+# See #90. Boots stable CHR per arch via @tikoci/quickchr, upgrades via
+# Box NPKs, crawls base (routeros-only) and extra (full) trees, publishes:
+#
+#   docs/nightly/{schema.raml,inspect.json,openapi.json}
+#   docs/nightly/extra/{schema.raml,inspect.json,openapi.json,
+#     deep-inspect.x86.json,deep-inspect.arm64.json,diff-deep-inspect.json,app.json}
+#   docs/nightly/nightly.json  # provenance §6 (buildWindow, packages per arch, rejected, absentRoots)
+#
+# Design notes:
+# - Separate workflow from auto.yaml so a flaky Box share never blocks stable/beta.
+# - Discover is a hard no-op when nightly hasn't moved (compare to docs/nightly/nightly.json).
+# - Uses nightly-build.ts (--phase base|extra) via quickchr so arch filter (generic
+#   routeros-*.npk duplicate) stays single-sourced. Two boots per x86 (base, extra)
+#   and one boot for arm64 extra is the simpler shape; one-boot/two-crawl would
+#   save ~30s but needs CHR reuse complexity.
+# - Each --phase run gets its own --output-dir so base/extra do not collide;
+#   nightly-build.ts stages inspect.json/schema.raml/openapi.json into that dir.
+# - Publish job merges x86+arm64 provenances, runs diff, regenerates docs-index.json,
+#   and publishes via publish-with-retry.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Force rebuild even if nightlyVersion hasn't changed"
+        type: boolean
+        default: false
+      nightly_version:
+        description: 'Override nightly version (e.g. 7.25_ab434) — skips discovery'
+        required: false
+        type: string
+
+jobs:
+  discover:
+    name: Discover nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      nightly_version: ${{ steps.discover.outputs.nightly_version }}
+      changed: ${{ steps.discover.outputs.changed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Discover latest nightly
+        id: discover
+        env:
+          FORCE: ${{ inputs.force }}
+          OVERRIDE: ${{ inputs.nightly_version }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${OVERRIDE:-}" ]; then
+            echo "Override nightly_version=$OVERRIDE (force)"
+            echo "nightly_version=$OVERRIDE" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Retry discovery 3× — Box API can be briefly flaky; do not fail the workflow
+          # on a probe error (soft no-op) unless force is set.
+          ATTEMPTS=3
+          for attempt in 1 2 3; do
+            echo "Discover attempt $attempt/$ATTEMPTS..."
+            if OUT=$(bun scripts/nightly-build.ts --dry-run --arch x86 2>&1); then
+              echo "$OUT"
+              NIGHTLY_VER=$(echo "$OUT" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?_ab[0-9]+' | head -1 || true)
+              if [ -z "$NIGHTLY_VER" ]; then
+                echo "::warning::Could not parse nightly version from dry-run output"
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+                echo "nightly_version=" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Discovered nightly $NIGHTLY_VER (attempt $attempt)"
+              echo "nightly_version=$NIGHTLY_VER" >> "$GITHUB_OUTPUT"
+
+              if [ "${FORCE:-false}" = "true" ]; then
+                echo "changed=true (force)"
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              if [ -f docs/nightly/nightly.json ]; then
+                PUBLISHED=$(jq -r '.nightlyVersion // empty' docs/nightly/nightly.json 2>/dev/null || true)
+                echo "Published nightlyVersion: ${PUBLISHED:-<none>}"
+                if [ "$PUBLISHED" = "$NIGHTLY_VER" ]; then
+                  echo "No new nightly — published $PUBLISHED equals discovered $NIGHTLY_VER (soft exit)"
+                  echo "changed=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+              else
+                echo "No docs/nightly/nightly.json — first publish"
+              fi
+
+              echo "changed=true"
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::warning::Discover attempt $attempt failed"
+            echo "$OUT" | tail -40 || true
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then sleep 5; fi
+          done
+
+          echo "::warning::Discover failed after $ATTEMPTS attempts — marking changed=false (soft no-op)"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "nightly_version=" >> "$GITHUB_OUTPUT"
+
+  nightly-x86:
+    name: "x86 nightly: ${{ needs.discover.outputs.nightly_version }}"
+    needs: discover
+    if: needs.discover.outputs.changed == 'true' && needs.discover.outputs.nightly_version != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    env:
+      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
+      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install QEMU (x86)
+        run: sudo apt-get update -y && sudo apt-get install -y qemu-system-x86 qemu-utils
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -la /dev/kvm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build x86 base (routeros-only)
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/nightly-x86-base /tmp/nightly-x86-extra
+          mkdir -p /tmp/nightly-x86-base
+          echo "→ x86 base (phase=base) — routeros-x86 only"
+          bun scripts/nightly-build.ts --arch x86 --phase base --output-dir /tmp/nightly-x86-base --output-suffix nightly-quickchr-x86-base
+          echo "→ x86 base done; staging"
+          ls -lh /tmp/nightly-x86-base/
+          test -f /tmp/nightly-x86-base/inspect.json
+          test -f /tmp/nightly-x86-base/schema.raml
+          test -f /tmp/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json
+          test -f /tmp/nightly-x86-base/openapi.json
+
+      - name: Build x86 extra (full NPK set)
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/nightly-x86-extra
+          echo "→ x86 extra (phase=extra) — full set"
+          bun scripts/nightly-build.ts --arch x86 --phase extra --output-dir /tmp/nightly-x86-extra --output-suffix nightly-quickchr-x86
+          echo "→ x86 extra done; staging"
+          ls -lh /tmp/nightly-x86-extra/
+          test -f /tmp/nightly-x86-extra/inspect.json
+          test -f /tmp/nightly-x86-extra/schema.raml
+          test -f /tmp/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json
+          test -f /tmp/nightly-x86-extra/openapi.json
+          if [ -f /tmp/nightly-x86-extra/app.json ]; then
+            echo "✓ app.json present ($(jq 'length' /tmp/nightly-x86-extra/app.json) entries)"
+          else
+            echo "::warning::app.json not produced for x86 extra (container package may be missing)"
+          fi
+
+      - name: Verify x86 outputs (floor already gated inside nightly-build.ts)
+        run: |
+          set -euo pipefail
+          echo "=== x86 base ==="
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json
+          echo "=== x86 extra ==="
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json
+          echo "=== nightly.json ==="
+          cat /tmp/nightly-x86-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
+
+      - name: Upload x86 staging
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-x86
+          path: |
+            /tmp/nightly-x86-base
+            /tmp/nightly-x86-extra
+          retention-days: 2
+
+      - name: Cleanup quickchr (always)
+        if: always()
+        run: |
+          bunx --bun quickchr list || true
+          bunx --bun quickchr remove restraml-nightly-quickchr-x86 --force || true
+
+  nightly-arm64:
+    name: "arm64 nightly: ${{ needs.discover.outputs.nightly_version }}"
+    needs: discover
+    if: needs.discover.outputs.changed == 'true' && needs.discover.outputs.nightly_version != ''
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
+      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install QEMU for aarch64
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq qemu-system-arm qemu-efi-aarch64 > /dev/null
+          qemu-system-aarch64 --version | head -1
+
+      - name: Probe accelerator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules > /dev/null
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+          if python3 -c '
+          import fcntl, os, sys
+          fd = os.open("/dev/kvm", os.O_RDWR | os.O_CLOEXEC)
+          ver = fcntl.ioctl(fd, 0xAE00, 0)
+          os.close(fd)
+          print(f"KVM API version: {ver}")
+          sys.exit(0 if ver == 12 else 1)
+          ' 2>/dev/null; then
+            echo "ARM_ACCEL=kvm" >> "$GITHUB_ENV"
+            echo "✓ KVM available"
+          else
+            echo "ARM_ACCEL=tcg" >> "$GITHUB_ENV"
+            echo "⚠ KVM not available — TCG"
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build arm64 extra (full NPK set, most informative)
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/nightly-arm64-extra
+          mkdir -p /tmp/nightly-arm64-extra
+          echo "→ arm64 extra (phase=extra) — full set (accel=${ARM_ACCEL:-unknown})"
+          bun scripts/nightly-build.ts --arch arm64 --phase extra --output-dir /tmp/nightly-arm64-extra --output-suffix nightly-quickchr-arm64
+          echo "→ arm64 extra done"
+          ls -lh /tmp/nightly-arm64-extra/
+          test -f /tmp/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json
+          test -f /tmp/nightly-arm64-extra/openapi.json
+          test -f /tmp/nightly-arm64-extra/inspect.json
+          test -f /tmp/nightly-arm64-extra/schema.raml
+
+      - name: Verify arm64 output
+        run: |
+          set -euo pipefail
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json
+          cat /tmp/nightly-arm64-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
+
+      - name: Upload arm64 staging
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-arm64
+          path: /tmp/nightly-arm64-extra
+          retention-days: 2
+
+      - name: Cleanup quickchr (always)
+        if: always()
+        run: |
+          bunx --bun quickchr list || true
+          bunx --bun quickchr remove restraml-nightly-quickchr-arm64 --force || true
+
+  publish-nightly:
+    name: "Publish nightly ${{ needs.discover.outputs.nightly_version }}"
+    needs: [discover, nightly-x86, nightly-arm64]
+    if: needs.discover.outputs.changed == 'true' && needs.discover.outputs.nightly_version != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure git for automated commits
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download x86 staging
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-x86
+          path: /tmp/nightly-stage
+
+      - name: Download arm64 staging
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-arm64
+          path: /tmp/nightly-stage
+
+      - name: Verify staged artifacts
+        run: |
+          set -euo pipefail
+          echo "=== Staged tree ==="
+          find /tmp/nightly-stage -type f | sort
+          echo "--- x86 base nightly.json ---"
+          cat /tmp/nightly-stage/nightly-x86-base/nightly.json | jq .
+          echo "--- x86 extra nightly.json ---"
+          cat /tmp/nightly-stage/nightly-x86-extra/nightly.json | jq .
+          echo "--- arm64 extra nightly.json ---"
+          cat /tmp/nightly-stage/nightly-arm64-extra/nightly.json | jq .
+
+      - name: Assemble docs/nightly/
+        run: |
+          set -euo pipefail
+          NIGHTLY_VER="${{ needs.discover.outputs.nightly_version }}"
+          echo "Assembling docs/nightly/ for $NIGHTLY_VER"
+
+          # Base tree is canonical x86 base (routeros-only) — maps to docs/nightly/
+          mkdir -p docs/nightly/extra
+
+          # Base (x86)
+          cp /tmp/nightly-stage/nightly-x86-base/inspect.json docs/nightly/inspect.json
+          cp /tmp/nightly-stage/nightly-x86-base/schema.raml docs/nightly/schema.raml
+          cp /tmp/nightly-stage/nightly-x86-base/openapi.json docs/nightly/openapi.json
+          # Also publish base deep-inspect as deep-inspect.json for inspect parity (optional, but matches versioned shape)
+          cp /tmp/nightly-stage/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json docs/nightly/deep-inspect.json
+
+          # Extra (x86 full)
+          cp /tmp/nightly-stage/nightly-x86-extra/inspect.json docs/nightly/extra/inspect.json
+          cp /tmp/nightly-stage/nightly-x86-extra/schema.raml docs/nightly/extra/schema.raml
+          cp /tmp/nightly-stage/nightly-x86-extra/openapi.json docs/nightly/extra/openapi.json
+          cp /tmp/nightly-stage/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json docs/nightly/extra/deep-inspect.x86.json
+
+          # Extra (arm64)
+          cp /tmp/nightly-stage/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json docs/nightly/extra/deep-inspect.arm64.json
+          # arm64 openapi is not published as canonical extra/openapi.json (keep x86 as canonical)
+
+          # app.json — only from extra where container is present; validate warn-only
+          if [ -f /tmp/nightly-stage/nightly-x86-extra/app.json ]; then
+            cp /tmp/nightly-stage/nightly-x86-extra/app.json docs/nightly/extra/app.json
+            echo "→ app.json: $(jq 'length' docs/nightly/extra/app.json) entries from x86 extra"
+            if ! bun -e '
+              import fs from "node:fs";
+              import Ajv from "ajv";
+              import addFormats from "ajv-formats";
+              const schema = JSON.parse(fs.readFileSync("docs/routeros-app-yaml-schema.latest.json","utf8"));
+              const ajv = new Ajv({allErrors:true, strict:false});
+              addFormats(ajv);
+              const valid = ajv.validateSchema(schema);
+              if (!valid) { console.error("root schema meta-invalid", ajv.errors); process.exit(1); }
+              console.log("✓ root app YAML schema meta-valid");
+            '; then
+              echo "::warning::root app schema meta-validation failed"
+            fi
+          else
+            echo "::warning::no app.json from x86 extra — container package may be absent this build"
+          fi
+
+          ls -lh docs/nightly/ docs/nightly/extra/
+
+      - name: Diff x86 vs arm64 extra
+        run: |
+          set -euo pipefail
+          echo "=== Text diff (x86 vs arm64 extra) ==="
+          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json | tee /tmp/diff.txt
+          echo ""
+          echo "=== JSON diff ==="
+          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json --json > docs/nightly/extra/diff-deep-inspect.json
+          echo "diff-deep-inspect.json: $(du -h docs/nightly/extra/diff-deep-inspect.json | cut -f1)"
+
+      - name: Verify diff is not a relabeled copy
+        run: |
+          ARM64_ONLY=$(jq '.counts.pathsOnlyB' docs/nightly/extra/diff-deep-inspect.json)
+          X86_ONLY=$(jq '.counts.pathsOnlyA' docs/nightly/extra/diff-deep-inspect.json)
+          echo "Paths only in arm64: $ARM64_ONLY"
+          echo "Paths only in x86:   $X86_ONLY"
+          if [ "$ARM64_ONLY" -lt 500 ]; then
+            echo "::error::arm64 has only $ARM64_ONLY unique paths (expected ≥500) — relabeled x86 or truncated crawl"
+            exit 1
+          fi
+
+      - name: Generate aggregated nightly.json
+        run: |
+          set -euo pipefail
+          bun -e '
+          import fs from "node:fs";
+          const r = (p) => JSON.parse(fs.readFileSync(p, "utf8"));
+          const xBase = r("/tmp/nightly-stage/nightly-x86-base/nightly.json");
+          const xExtra = r("/tmp/nightly-stage/nightly-x86-extra/nightly.json");
+          const aExtra = r("/tmp/nightly-stage/nightly-arm64-extra/nightly.json");
+          // nightlyVersion must agree; take max by compareAb if they differ (race where Box rolled between jobs)
+          const versions = [xExtra.nightlyVersion, aExtra.nightlyVersion];
+          const parseAb = (v) => { const m = v.match(/^(\d+)\.(\d+)(?:\.(\d+))?_ab(\d+)$/); return m ? [Number(m[1]), Number(m[2]), Number(m[3]??0), Number(m[4])] : null; };
+          const compareAb = (a,b) => { const pa=parseAb(a), pb=parseAb(b); if(!pa&&!pb) return a.localeCompare(b); if(!pa) return 1; if(!pb) return -1; for(let i=0;i<4;i++) if(pa[i]!==pb[i]) return pa[i]-pb[i]; return 0; };
+          const nightlyVersion = [...versions].sort(compareAb).at(-1);
+          // buildWindow: earliest = min, latest = max across both arches
+          const windows = [xExtra.buildWindow, aExtra.buildWindow].filter(Boolean);
+          const allTimes = windows.flatMap(w => [w.earliest, w.latest]).filter(Boolean).sort();
+          const buildWindow = allTimes.length ? { earliest: allTimes[0], latest: allTimes[allTimes.length-1] } : null;
+          // provenance: take source from xExtra (token etc) — they should match
+          const source = xExtra.source ?? aExtra.source;
+          const baseVersion = xExtra.baseVersion ?? xBase.baseVersion;
+          const builtAt = new Date().toISOString();
+          // Use the most recent builtAt among provenances? No — use publish time
+          const aggregated = {
+            nightlyVersion,
+            builtAt,
+            baseVersion,
+            source,
+            buildWindow,
+            packages: {
+              x86: { count: xExtra.packageCount, names: xExtra.packageNames, npks: xExtra.packages?.npks ?? [], phaseFiles: xExtra.phaseFiles },
+              arm64: { count: aExtra.packageCount, names: aExtra.packageNames, npks: aExtra.packages?.npks ?? [], phaseFiles: aExtra.phaseFiles },
+              rejected: xExtra.packages?.rejected ?? aExtra.packages?.rejected ?? [],
+            },
+            absentRoots: xExtra.absentRoots ?? ["dude","openflow","tr069-client","user-manager"],
+            // Full provenance per arch for debugging
+            provenance: { x86: { base: xBase, extra: xExtra }, arm64: { extra: aExtra } },
+          };
+          fs.mkdirSync("docs/nightly", { recursive: true });
+          fs.writeFileSync("docs/nightly/nightly.json", JSON.stringify(aggregated, null, 2) + "\n");
+          console.log(JSON.stringify(aggregated, null, 2));
+          // Also update nightlyVersion in discover output check for next run — already done
+          '
+          cat docs/nightly/nightly.json | jq .
+
+      - name: Rebuild docs-index.json
+        run: bun scripts/build-docs-index.mjs
+
+      - name: Verify docs-index nightly sibling
+        run: |
+          jq '{latestVersion,latestStableVersion,nightly}' docs/docs-index.json
+          NIGHTLY=$(jq -r '.nightly.nightlyVersion // empty' docs/docs-index.json)
+          if [ -z "$NIGHTLY" ]; then echo "::error::docs-index.json nightly missing after rebuild"; exit 1; fi
+          echo "✓ docs-index nightly $NIGHTLY"
+
+      - name: Generate step summary
+        run: |
+          echo "### Nightly ${{ needs.discover.outputs.nightly_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Artifact | Size |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          for f in docs/nightly/inspect.json docs/nightly/schema.raml docs/nightly/openapi.json docs/nightly/deep-inspect.json docs/nightly/extra/inspect.json docs/nightly/extra/schema.raml docs/nightly/extra/openapi.json docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json docs/nightly/extra/diff-deep-inspect.json docs/nightly/extra/app.json docs/nightly/nightly.json; do
+            if [ -f "$f" ]; then echo "| $f | $(du -h "$f" | cut -f1) |" >> "$GITHUB_STEP_SUMMARY"; fi
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat docs/nightly/nightly.json | jq . >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/diff.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish nightly to docs
+        uses: ./.github/actions/publish-with-retry
+        with:
+          publish-paths: |
+            docs/nightly/
+          commit-message: Publish nightly ${{ needs.discover.outputs.nightly_version }} [${{ github.workflow }}]
+
+      - name: Upload nightly build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-${{ needs.discover.outputs.nightly_version }}
+          path: |
+            docs/nightly/nightly.json
+            docs/nightly/inspect.json
+            docs/nightly/schema.raml
+            docs/nightly/openapi.json
+            docs/nightly/deep-inspect.json
+            docs/nightly/extra/inspect.json
+            docs/nightly/extra/schema.raml
+            docs/nightly/extra/openapi.json
+            docs/nightly/extra/deep-inspect.x86.json
+            docs/nightly/extra/deep-inspect.arm64.json
+            docs/nightly/extra/diff-deep-inspect.json
+            docs/nightly/extra/app.json

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -82,7 +82,10 @@ jobs:
             echo "Discover attempt $attempt/$ATTEMPTS..."
             if OUT=$(bun scripts/nightly-build.ts --dry-run --arch x86 2>&1); then
               echo "$OUT"
-              NIGHTLY_VER=$(echo "$OUT" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?_ab[0-9]+' | head -1 || true)
+              # Read the machine-readable marker, NOT free-text log lines: when the
+              # Box share holds two ab builds mid-upload the log lists both, and a
+              # bare grep would pick the older one.
+              NIGHTLY_VER=$(echo "$OUT" | sed -n 's/^nightly-version=//p' | head -1 || true)
               if [ -z "$NIGHTLY_VER" ]; then
                 echo "::warning::Could not parse nightly version from dry-run output"
                 echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -131,9 +134,11 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
-    env:
-      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
-      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
+    # No MIKROTIK_* license secrets here: quickchr only licenses when passed
+    # license: "p1" (and reads MIKROTIK_WEB_ACCOUNT/PASSWORD, not the names
+    # deep-inspect-multi-arch.yaml uses). The account is currently out of trial
+    # licences anyway ("too many trial licences"), so nightly runs free-tier —
+    # same as the multi-arch workflow does in practice.
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -155,30 +160,36 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build x86 base (routeros-only)
+        # nightly_version can originate from a workflow_dispatch input, so it goes
+        # through env: rather than being interpolated into the shell body.
+        env:
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
         run: |
           set -euo pipefail
           rm -rf /tmp/nightly-x86-base /tmp/nightly-x86-extra
           mkdir -p /tmp/nightly-x86-base
           echo "→ x86 base (phase=base) — routeros-x86 only"
-          bun scripts/nightly-build.ts --arch x86 --phase base --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-x86-base --output-suffix nightly-quickchr-x86-base
+          bun scripts/nightly-build.ts --arch x86 --phase base --nightly-version "$NIGHTLY_VERSION" --output-dir /tmp/nightly-x86-base --output-suffix x86-base
           echo "→ x86 base done; staging"
           ls -lh /tmp/nightly-x86-base/
           test -f /tmp/nightly-x86-base/inspect.json
           test -f /tmp/nightly-x86-base/schema.raml
-          test -f /tmp/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json
+          test -f /tmp/nightly-x86-base/deep-inspect.x86-base.json
           test -f /tmp/nightly-x86-base/openapi.json
 
       - name: Build x86 extra (full NPK set)
+        env:
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/nightly-x86-extra
           echo "→ x86 extra (phase=extra) — full set"
-          bun scripts/nightly-build.ts --arch x86 --phase extra --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-x86-extra --output-suffix nightly-quickchr-x86
+          bun scripts/nightly-build.ts --arch x86 --phase extra --nightly-version "$NIGHTLY_VERSION" --output-dir /tmp/nightly-x86-extra --output-suffix x86
           echo "→ x86 extra done; staging"
           ls -lh /tmp/nightly-x86-extra/
           test -f /tmp/nightly-x86-extra/inspect.json
           test -f /tmp/nightly-x86-extra/schema.raml
-          test -f /tmp/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json
+          test -f /tmp/nightly-x86-extra/deep-inspect.x86.json
           test -f /tmp/nightly-x86-extra/openapi.json
           if [ -f /tmp/nightly-x86-extra/app.json ]; then
             echo "✓ app.json present ($(jq 'length' /tmp/nightly-x86-extra/app.json) entries)"
@@ -190,11 +201,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "=== x86 base ==="
-          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-base/deep-inspect.x86-base.json
           echo "=== x86 extra ==="
-          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-x86-extra/deep-inspect.x86.json
           echo "=== nightly.json ==="
           cat /tmp/nightly-x86-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
+          # Drop what the publish job never reads: downloaded NPKs (~100 MB of
+          # MikroTik binaries) and the suffixed OpenAPI duplicate of openapi.json.
+          rm -rf /tmp/nightly-x86-base/npks /tmp/nightly-x86-extra/npks
+          rm -f /tmp/nightly-x86-base/openapi.x86-base.json /tmp/nightly-x86-extra/openapi.x86.json
 
       - name: Upload x86 staging
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -209,7 +224,7 @@ jobs:
         if: always()
         run: |
           bunx --bun quickchr list || true
-          bunx --bun quickchr remove restraml-nightly-quickchr-x86 --force || true
+          bunx --bun quickchr remove restraml-nightly-x86 --force || true
 
   nightly-arm64:
     name: "arm64 nightly: ${{ needs.discover.outputs.nightly_version }}"
@@ -219,9 +234,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-    env:
-      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
-      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
+    # See the x86 job for why no MIKROTIK_* license secrets are wired here.
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -229,8 +242,13 @@ jobs:
       - name: Install QEMU for aarch64
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq qemu-system-arm qemu-efi-aarch64 > /dev/null
+          # qemu-utils is required on arm64: quickchr builds the per-machine EFI
+          # vars pflash with `qemu-img convert -f raw -O qcow2` on every aarch64
+          # launch (quickchr src/lib/qemu.ts prepareEfiVars). Without it the CHR
+          # never boots. The x86 boot disk stays raw and needs no conversion.
+          sudo apt-get install -y -qq qemu-system-arm qemu-efi-aarch64 qemu-utils > /dev/null
           qemu-system-aarch64 --version | head -1
+          qemu-img --version | head -1
 
       - name: Probe accelerator
         run: |
@@ -259,15 +277,17 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build arm64 extra (full NPK set, most informative)
+        env:
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
         run: |
           set -euo pipefail
           rm -rf /tmp/nightly-arm64-extra
           mkdir -p /tmp/nightly-arm64-extra
           echo "→ arm64 extra (phase=extra) — full set (accel=${ARM_ACCEL:-unknown})"
-          bun scripts/nightly-build.ts --arch arm64 --phase extra --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-arm64-extra --output-suffix nightly-quickchr-arm64
+          bun scripts/nightly-build.ts --arch arm64 --phase extra --nightly-version "$NIGHTLY_VERSION" --output-dir /tmp/nightly-arm64-extra --output-suffix arm64
           echo "→ arm64 extra done"
           ls -lh /tmp/nightly-arm64-extra/
-          test -f /tmp/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json
+          test -f /tmp/nightly-arm64-extra/deep-inspect.arm64.json
           test -f /tmp/nightly-arm64-extra/openapi.json
           test -f /tmp/nightly-arm64-extra/inspect.json
           test -f /tmp/nightly-arm64-extra/schema.raml
@@ -275,8 +295,11 @@ jobs:
       - name: Verify arm64 output
         run: |
           set -euo pipefail
-          jq '._meta.completionStats.argsTotal' /tmp/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json
+          jq '._meta.completionStats.argsTotal' /tmp/nightly-arm64-extra/deep-inspect.arm64.json
           cat /tmp/nightly-arm64-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
+          # See the x86 job — NPKs and the suffixed OpenAPI duplicate are not published.
+          rm -rf /tmp/nightly-arm64-extra/npks
+          rm -f /tmp/nightly-arm64-extra/openapi.arm64.json
 
       - name: Upload arm64 staging
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -289,7 +312,7 @@ jobs:
         if: always()
         run: |
           bunx --bun quickchr list || true
-          bunx --bun quickchr remove restraml-nightly-quickchr-arm64 --force || true
+          bunx --bun quickchr remove restraml-nightly-arm64 --force || true
 
   publish-nightly:
     name: "Publish nightly ${{ needs.discover.outputs.nightly_version }}"
@@ -314,6 +337,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Artifact paths are relative to the least common ancestor of the uploaded
+      # files. The x86 job uploads two directories, so its archive keeps the
+      # nightly-x86-base/ and nightly-x86-extra/ prefixes; the arm64 job uploads
+      # one directory, so its archive is rooted *inside* it and must be unpacked
+      # into a matching directory here.
       - name: Download x86 staging
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -324,13 +352,21 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: nightly-arm64
-          path: /tmp/nightly-stage
+          path: /tmp/nightly-stage/nightly-arm64-extra
 
       - name: Verify staged artifacts
         run: |
           set -euo pipefail
           echo "=== Staged tree ==="
           find /tmp/nightly-stage -type f | sort
+          # Fail with a readable message if an artifact unpacked at an unexpected
+          # depth, instead of a bare "cat: no such file" three lines down.
+          for d in nightly-x86-base nightly-x86-extra nightly-arm64-extra; do
+            if [ ! -f "/tmp/nightly-stage/$d/nightly.json" ]; then
+              echo "::error::staged artifact layout unexpected — /tmp/nightly-stage/$d/nightly.json missing"
+              exit 1
+            fi
+          done
           echo "--- x86 base nightly.json ---"
           cat /tmp/nightly-stage/nightly-x86-base/nightly.json | jq .
           echo "--- x86 extra nightly.json ---"
@@ -339,10 +375,11 @@ jobs:
           cat /tmp/nightly-stage/nightly-arm64-extra/nightly.json | jq .
 
       - name: Assemble docs/nightly/
+        env:
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
         run: |
           set -euo pipefail
-          NIGHTLY_VER="${{ needs.discover.outputs.nightly_version }}"
-          echo "Assembling docs/nightly/ for $NIGHTLY_VER"
+          echo "Assembling docs/nightly/ for $NIGHTLY_VERSION"
 
           # Base tree is canonical x86 base (routeros-only) — maps to docs/nightly/
           # Clear the overwritten single-slot so a previous app.json (or other file)
@@ -355,35 +392,27 @@ jobs:
           cp /tmp/nightly-stage/nightly-x86-base/schema.raml docs/nightly/schema.raml
           cp /tmp/nightly-stage/nightly-x86-base/openapi.json docs/nightly/openapi.json
           # Also publish base deep-inspect as deep-inspect.json for inspect parity (optional, but matches versioned shape)
-          cp /tmp/nightly-stage/nightly-x86-base/deep-inspect.nightly-quickchr-x86-base.json docs/nightly/deep-inspect.json
+          cp /tmp/nightly-stage/nightly-x86-base/deep-inspect.x86-base.json docs/nightly/deep-inspect.json
 
           # Extra (x86 full)
           cp /tmp/nightly-stage/nightly-x86-extra/inspect.json docs/nightly/extra/inspect.json
           cp /tmp/nightly-stage/nightly-x86-extra/schema.raml docs/nightly/extra/schema.raml
           cp /tmp/nightly-stage/nightly-x86-extra/openapi.json docs/nightly/extra/openapi.json
-          cp /tmp/nightly-stage/nightly-x86-extra/deep-inspect.nightly-quickchr-x86.json docs/nightly/extra/deep-inspect.x86.json
+          cp /tmp/nightly-stage/nightly-x86-extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.x86.json
 
           # Extra (arm64)
-          cp /tmp/nightly-stage/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json docs/nightly/extra/deep-inspect.arm64.json
+          cp /tmp/nightly-stage/nightly-arm64-extra/deep-inspect.arm64.json docs/nightly/extra/deep-inspect.arm64.json
           # arm64 openapi is not published as canonical extra/openapi.json (keep x86 as canonical)
 
-          # app.json — only from extra where container is present; validate warn-only
+          # app.json — only from extra where container is present. Published raw,
+          # unvalidated: nightly is expected to run ahead of the /app schema, and
+          # per-version schema generation for nightly is deferred (N6). The old
+          # block here only re-checked that our own committed schema was valid
+          # JSON Schema — it never looked at app.json — so it is gone rather than
+          # left in place implying coverage that does not exist.
           if [ -f /tmp/nightly-stage/nightly-x86-extra/app.json ]; then
             cp /tmp/nightly-stage/nightly-x86-extra/app.json docs/nightly/extra/app.json
-            echo "→ app.json: $(jq 'length' docs/nightly/extra/app.json) entries from x86 extra"
-            if ! bun -e '
-              import fs from "node:fs";
-              import Ajv from "ajv";
-              import addFormats from "ajv-formats";
-              const schema = JSON.parse(fs.readFileSync("docs/routeros-app-yaml-schema.latest.json","utf8"));
-              const ajv = new Ajv({allErrors:true, strict:false});
-              addFormats(ajv);
-              const valid = ajv.validateSchema(schema);
-              if (!valid) { console.error("root schema meta-invalid", ajv.errors); process.exit(1); }
-              console.log("✓ root app YAML schema meta-valid");
-            '; then
-              echo "::warning::root app schema meta-validation failed"
-            fi
+            echo "→ app.json: $(jq 'length' docs/nightly/extra/app.json) entries from x86 extra (published raw, not schema-validated)"
           else
             echo "::warning::no app.json from x86 extra — container package may be absent this build"
           fi
@@ -402,10 +431,19 @@ jobs:
 
       - name: Verify diff is not a relabeled copy
         run: |
+          set -euo pipefail
           ARM64_ONLY=$(jq '.counts.pathsOnlyB' docs/nightly/extra/diff-deep-inspect.json)
           X86_ONLY=$(jq '.counts.pathsOnlyA' docs/nightly/extra/diff-deep-inspect.json)
           echo "Paths only in arm64: $ARM64_ONLY"
           echo "Paths only in x86:   $X86_ONLY"
+          # Without this, a shape change that makes jq emit null turns the gate
+          # below into a silent pass ([ null -lt 500 ] errors, `if` reads false).
+          case "$ARM64_ONLY" in
+            ''|*[!0-9]*) echo "::error::pathsOnlyB is not a number ('$ARM64_ONLY') — diff JSON shape changed"; exit 1 ;;
+          esac
+          # Reference: full all_packages builds run ~1,561 arm64-only paths
+          # (docs/7.24rc2/extra/diff-deep-inspect.json); nightly's arm64 NPK set
+          # is larger than its x86 one, so 500 is a floor with real headroom.
           if [ "$ARM64_ONLY" -lt 500 ]; then
             echo "::error::arm64 has only $ARM64_ONLY unique paths (expected ≥500) — relabeled x86 or truncated crawl"
             exit 1
@@ -467,8 +505,10 @@ jobs:
           echo "✓ docs-index nightly $NIGHTLY"
 
       - name: Generate step summary
+        env:
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
         run: |
-          echo "### Nightly ${{ needs.discover.outputs.nightly_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Nightly $NIGHTLY_VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Artifact | Size |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: nightly-docs
+  cancel-in-progress: false
+
 jobs:
   discover:
     name: Discover nightly
@@ -48,7 +52,7 @@ jobs:
       changed: ${{ steps.discover.outputs.changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -132,7 +136,7 @@ jobs:
       MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install QEMU (x86)
         run: sudo apt-get update -y && sudo apt-get install -y qemu-system-x86 qemu-utils
@@ -156,7 +160,7 @@ jobs:
           rm -rf /tmp/nightly-x86-base /tmp/nightly-x86-extra
           mkdir -p /tmp/nightly-x86-base
           echo "→ x86 base (phase=base) — routeros-x86 only"
-          bun scripts/nightly-build.ts --arch x86 --phase base --output-dir /tmp/nightly-x86-base --output-suffix nightly-quickchr-x86-base
+          bun scripts/nightly-build.ts --arch x86 --phase base --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-x86-base --output-suffix nightly-quickchr-x86-base
           echo "→ x86 base done; staging"
           ls -lh /tmp/nightly-x86-base/
           test -f /tmp/nightly-x86-base/inspect.json
@@ -169,7 +173,7 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/nightly-x86-extra
           echo "→ x86 extra (phase=extra) — full set"
-          bun scripts/nightly-build.ts --arch x86 --phase extra --output-dir /tmp/nightly-x86-extra --output-suffix nightly-quickchr-x86
+          bun scripts/nightly-build.ts --arch x86 --phase extra --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-x86-extra --output-suffix nightly-quickchr-x86
           echo "→ x86 extra done; staging"
           ls -lh /tmp/nightly-x86-extra/
           test -f /tmp/nightly-x86-extra/inspect.json
@@ -193,7 +197,7 @@ jobs:
           cat /tmp/nightly-x86-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
 
       - name: Upload x86 staging
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-x86
           path: |
@@ -220,7 +224,7 @@ jobs:
       MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install QEMU for aarch64
         run: |
@@ -260,7 +264,7 @@ jobs:
           rm -rf /tmp/nightly-arm64-extra
           mkdir -p /tmp/nightly-arm64-extra
           echo "→ arm64 extra (phase=extra) — full set (accel=${ARM_ACCEL:-unknown})"
-          bun scripts/nightly-build.ts --arch arm64 --phase extra --output-dir /tmp/nightly-arm64-extra --output-suffix nightly-quickchr-arm64
+          bun scripts/nightly-build.ts --arch arm64 --phase extra --nightly-version "${{ needs.discover.outputs.nightly_version }}" --output-dir /tmp/nightly-arm64-extra --output-suffix nightly-quickchr-arm64
           echo "→ arm64 extra done"
           ls -lh /tmp/nightly-arm64-extra/
           test -f /tmp/nightly-arm64-extra/deep-inspect.nightly-quickchr-arm64.json
@@ -275,7 +279,7 @@ jobs:
           cat /tmp/nightly-arm64-extra/nightly.json | jq '{nightlyVersion, arch, phase, packageCount, builtAt}'
 
       - name: Upload arm64 staging
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-arm64
           path: /tmp/nightly-arm64-extra
@@ -297,7 +301,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Configure git for automated commits
         run: |
@@ -311,13 +315,13 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download x86 staging
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: nightly-x86
           path: /tmp/nightly-stage
 
       - name: Download arm64 staging
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: nightly-arm64
           path: /tmp/nightly-stage
@@ -488,7 +492,7 @@ jobs:
           commit-message: Publish nightly ${{ needs.discover.outputs.nightly_version }} [${{ github.workflow }}]
 
       - name: Upload nightly build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-${{ needs.discover.outputs.nightly_version }}
           path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ All pages in `docs/` are static HTML files served by GitHub Pages. Rules:
 | `scripts/test-ros-api.sh` | Integration + stress tests (ros-api-protocol) against local CHR |
 | `scripts/benchmark-qemu.sh` | REST vs native API timing benchmark against local CHR |
 | `scripts/deep-inspect-multi-arch.ts` | Per-arch deep-inspect orchestrator (quickchr, x86 + arm64) |
+| `scripts/nightly-build.ts` | Nightly (ab) driver: stable CHR → nightly NPK upgrade → crawl; artifact names must not carry harness names |
 | `scripts/diff-deep-inspect.ts` | Diff two deep-inspect.<arch>.json files (enum drift + path delta) |
 | `docs/index.html` | Main GitHub Pages SPA (reference for new pages) |
 | `docs/lookup.html` | RouterOS command search tool — fully event-driven, no submit buttons |
@@ -234,6 +235,7 @@ All pages in `docs/` are static HTML files served by GitHub Pages. Rules:
 | `.github/workflows/manual-using-extra-docker-in-docker.yaml` | Build: schema + extra packages |
 | `.github/workflows/appyamlschemas.yaml` | Build: validate and publish /app YAML schemas per-version |
 | `.github/workflows/deep-inspect-multi-arch.yaml` | Build: per-arch deep-inspect (x86 KVM + arm64 KVM/TCG fallback) with diff |
+| `.github/workflows/nightly.yaml` | Build: nightly (ab) single overwritten slot → `docs/nightly/` (see CLAUDE.md) |
 | `.github/workflows/manual-from-secrets.yaml` | Build: using a real RouterOS device |
 | `docs/restraml-shared.js` | Shared JS utilities for all tool pages (version parsing, theme, share modal) |
 | `docs/restraml-shared.css` | Shared CSS for all tool pages (fonts, logo, theme, guide, modal, utilities) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ restraml/
 │   ├── test-ros-api.sh             # Integration + stress tests (ros-api-protocol) against local CHR
 │   ├── benchmark-qemu.sh           # REST vs native API timing benchmark against local CHR
 │   ├── deep-inspect-multi-arch.ts  # Per-arch deep-inspect orchestrator (quickchr library, x86 + arm64)
+│   ├── nightly-build.ts            # Nightly (ab) build driver: stable CHR → nightly NPK upgrade → crawl
 │   ├── diff-deep-inspect.ts        # Diff two deep-inspect.<arch>.json files (enum drift + path delta)
 │   ├── build-docs-index.mjs        # Generate docs/docs-index.json from the checked-in docs tree
 │   ├── experiment-arm64-reboot-timing.sh # Local QEMU arm64 reboot-timing experiment helper
@@ -74,7 +75,11 @@ restraml/
 │   │   ├── app.json                             # Raw GET /rest/app output (built-in /app YAMLs)
 │   │   ├── routeros-app-yaml-schema.json        # /app YAML schema for this version
 │   │   └── routeros-app-yaml-store-schema.json  # /app store schema for this version
-│   └── {version}/extra/  # Same files, but built with all_packages (extra features)
+│   ├── {version}/extra/  # Same files, but built with all_packages (extra features)
+│   └── nightly/          # Single overwritten slot for the mt.lv/nightly-build (ab) train
+│       ├── {schema.raml,inspect.json,openapi.json,deep-inspect.json}  # x86 base phase
+│       ├── nightly.json  # Provenance: nightlyVersion, buildWindow, per-arch packages, absentRoots
+│       └── extra/        # x86 extra phase + deep-inspect.{x86,arm64}.json + diff + app.json
 ├── CLAUDE.md             # Full architecture guide for AI agents
 ├── AGENTS.md             # GitHub Copilot agent-specific instructions
 └── .github/
@@ -86,6 +91,7 @@ restraml/
         ├── manual-using-extra-docker-in-docker.yaml     # Build: schema with extra packages
         ├── appyamlschemas.yaml                          # Build: validate and publish /app YAML schemas
         ├── deep-inspect-multi-arch.yaml                 # Build: per-arch deep-inspect (x86 KVM + arm64 KVM/TCG fallback) with diff
+        ├── nightly.yaml                                 # Build: nightly (ab) single slot → docs/nightly/
         ├── manual-from-secrets.yaml                     # Build: using a real RouterOS device (secrets)
         ├── codeql.yml                                   # Code scanning (JS/TS + GitHub Actions)
         └── dependency-review.yml                        # PR dependency review
@@ -959,11 +965,45 @@ half mid-flight, then probes the router — clean queue = &lt;5 s; ghost regress
 | `manual-using-extra-docker-in-docker.yaml` | Manual (`rosver` input) or `auto.yaml` | Same as above + installs extra packages, commits to `/docs/{version}/extra/` |
 | `appyamlschemas.yaml` | Manual (`rosver` input) or `auto.yaml` | Boots CHR with extra packages, validates /app YAML schemas (exit codes 0/1/2), commits `app.json` always; commits per-version schemas only on full pass (exit 0); files GitHub issue on exit 2 |
 | `deep-inspect-multi-arch.yaml` | Manual (`rosver` input) or `auto.yaml` | Boots x86 (KVM) and arm64 (KVM preferred, TCG fallback) CHRs with extra packages in parallel, runs live deep-inspect crawl on each, diffs results, publishes `deep-inspect.{x86,arm64}.json` and `diff-deep-inspect.json` to `/docs/{version}/extra/`. Per-arch OpenAPI publication is deferred to `BACKLOG.md` P2. |
+| `nightly.yaml` | Daily cron (06:00 UTC) + manual | Discovers the current `mt.lv/nightly-build` (ab) version, boots stable CHRs via quickchr, upgrades them with the nightly NPKs, crawls x86 base + x86 extra + arm64 extra, and publishes the single overwritten `docs/nightly/` slot. Independent of `auto.yaml` so a flaky Box share never blocks stable/beta. Accepts `force` and `nightly_version` dispatch inputs. |
 | `manual-from-secrets.yaml` | Manual | Builds using a real router via GitHub Secrets (no QEMU) |
 | `codeql.yml` | Push + PR + weekly schedule | Runs repository-managed CodeQL for JavaScript/TypeScript and GitHub Actions, using repo path ignores for generated versioned docs artifacts |
 | `dependency-review.yml` | Pull requests | Uses GitHub dependency review to block new high-severity vulnerable dependency changes |
 
 All builds commit schema files to `main` as `github-actions[bot]` and publish via GitHub Pages.
+
+### `nightly.yaml` — the `docs/nightly/` single slot
+
+MikroTik's nightly ("ab") builds are published only as `.npk` files on a Box/Seafile share behind
+`https://mt.lv/nightly-build` — there is no nightly CHR disk image. `scripts/nightly-build.ts`
+therefore boots a **stable** CHR via quickchr, uploads the arch-filtered nightly NPKs over SCP,
+reboots, verifies `/system/resource` reports the nightly version, and only then runs the normal
+`rest2raml.js` + `deep-inspect.ts` collection. Output goes to one overwritten `docs/nightly/`
+directory — never one directory per `ab` build (see #90 for the storage rationale).
+
+Rules that are easy to get wrong:
+
+- **Harness names must not reach `docs/`.** `docs/nightly/nightly.json` embeds the full per-arch
+  provenance, including `outputSuffix` and `machineName`. Those are named for the *artifact*
+  (`x86`, `x86-base`, `arm64`, `restraml-nightly-<arch>`), never for quickchr or any other tool
+  that happens to run the build.
+- **Discovery reads a marker, not prose.** `nightly-build.ts --dry-run` prints
+  `nightly-version=<ver>` as a dedicated line and `nightly.yaml` extracts exactly that. The Box
+  share holds two `ab` builds during the upload window, so scraping any other log line can select
+  the older one.
+- **Each `--phase` gets its own `--output-dir`.** Base and extra crawls otherwise collide on the
+  `ros-*` artifacts at the repo root, and the `deep-inspect.<suffix>.json` floor gate would
+  validate the wrong phase.
+- **Package floors are phase-aware** (`getExpectedMinPackageCount`, `getArgsTotalFloor`). The
+  nightly NPK set is smaller than `all_packages` — the Box share carries no `dude`, `openflow`,
+  `tr069-client`, or `user-manager`, which is why `nightly.json` records `absentRoots`. Do not
+  compare nightly `argsTotal` against the versioned `docs/{version}/extra/` numbers without
+  accounting for that.
+- **`@tikoci/quickchr` is a devDependency from npm** (`^0.4.7`), not `file:../quickchr`. CI runs
+  `bun install --frozen-lockfile` on a runner where no sibling checkout exists, so a `file:` path
+  fails the install outright. To iterate against a local quickchr working copy, use
+  `bun link` in `../quickchr` then `bun link @tikoci/quickchr` here — do not re-add the `file:`
+  dependency to `package.json`.
 
 ### `auto.yaml` — `skip_versions` Input
 
@@ -1104,6 +1144,7 @@ These rules apply to **all agents working on CI workflows** in this repository:
 | Package | Used by | Purpose |
 |---|---|---|
 | `js-yaml` | `rest2raml.js`, `appyamlvalidate.js` (Bun) | Serialize RAML output as YAML; parse /app YAML for validation |
+| `@tikoci/quickchr` | `scripts/nightly-build.ts`, `scripts/deep-inspect-multi-arch.ts` (dev) | Boots/manages CHR VMs via QEMU. Installed from npm so CI can resolve it; `bun link` for local iteration |
 | `ajv` | `appyamlvalidate.js` (Bun) | JSON Schema validation (draft-07) for /app YAML schemas |
 | `ajv-formats` | `appyamlvalidate.js` (Bun) | AJV plugin for format validators (uri, email, etc.) |
 | `@apidevtools/swagger-parser` | `validate-openapi.ts` (Bun) | OpenAPI 3.0 schema validation |

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "restraml",
       "dependencies": {
-        "@tikoci/quickchr": "file:../quickchr",
         "js-yaml": "^4.1.1",
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
         "@biomejs/biome": "^2.0.0",
+        "@tikoci/quickchr": "^0.4.7",
         "actionlint": "^2.0.6",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
@@ -50,29 +50,11 @@
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
-
-    "@tikoci/quickchr": ["@tikoci/quickchr@file:../quickchr", { "dependencies": { "@clack/prompts": "^0.11.0", "typescript": "^5" }, "devDependencies": { "@biomejs/biome": "^2.4.10", "@types/bun": "^1.3.11", "markdownlint-cli2": "^0.21.0" }, "bin": { "quickchr": "src/cli/index.ts" } }],
-
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
-
-    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+    "@tikoci/quickchr": ["@tikoci/quickchr@0.4.7", "", { "dependencies": { "@clack/prompts": "^0.11.0", "fflate": "^0.8.2", "typescript": "^5" }, "bin": { "quickchr": "src/cli/index.ts" } }, "sha512-RV+HqcRZM0+WN9w1/EwNCQiPxVyi1E5GC2bxQU7h3KVcniIKH/OmK6xD1JEbvDhdwPEHr0jJeg2Nb6TEvWnmTg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
-
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
-
-    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "actionlint": ["actionlint@2.0.6", "", {}, "sha512-tNx8f48yJNSLXTIygGntu5dSZlIZblDt8sR7pIs7EEmmb2PkEF87d+3UKZV2GUgCuN9Awj7k4ZPrwdAxFWEqgw=="],
 
@@ -82,209 +64,43 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
 
-    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
-
-    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
-
-    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
-
-    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
-
-    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
-
-    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
-
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
-    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
-
-    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "globby": ["globby@16.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ=="],
-
-    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
-
-    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
-
-    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
-
-    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
-    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
-
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
-
-    "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
-
-    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
-
-    "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
-
-    "markdownlint": ["markdownlint@0.40.0", "", { "dependencies": { "micromark": "4.0.2", "micromark-core-commonmark": "2.0.3", "micromark-extension-directive": "4.0.0", "micromark-extension-gfm-autolink-literal": "2.1.0", "micromark-extension-gfm-footnote": "2.1.0", "micromark-extension-gfm-table": "2.1.1", "micromark-extension-math": "3.1.0", "micromark-util-types": "2.0.2", "string-width": "8.1.0" } }, "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg=="],
-
-    "markdownlint-cli2": ["markdownlint-cli2@0.21.0", "", { "dependencies": { "globby": "16.1.0", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "markdown-it": "14.1.1", "markdownlint": "0.40.0", "markdownlint-cli2-formatter-default": "0.0.6", "micromatch": "4.0.8" }, "bin": { "markdownlint-cli2": "markdownlint-cli2-bin.mjs" } }, "sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw=="],
-
-    "markdownlint-cli2-formatter-default": ["markdownlint-cli2-formatter-default@0.0.6", "", { "peerDependencies": { "markdownlint-cli2": ">=0.0.4" } }, "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ=="],
-
-    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
-
-    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
-
-    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
-
-    "micromark-extension-directive": ["micromark-extension-directive@4.0.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg=="],
-
-    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
-
-    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
-
-    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
-
-    "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
-
-    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
-
-    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
-
-    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
-
-    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
-
-    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
-
-    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
-
-    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
-
-    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
-
-    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
-
-    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
-
-    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
-
-    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
-
-    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
-
-    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
-
-    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
-
-    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
-
-    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
-
-    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
-
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
-
-    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
-
-    "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
-
-    "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
-
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
-
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "webapi-parser": ["webapi-parser@0.5.0", "", { "dependencies": { "ajv": "6.5.2" } }, "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw=="],
 
-    "@tikoci/quickchr/@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
-
-    "@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
-
     "webapi-parser/ajv": ["ajv@6.5.2", "", { "dependencies": { "fast-deep-equal": "^2.0.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.1" } }, "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
-
-    "@tikoci/quickchr/@biomejs/biome/@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
     "webapi-parser/ajv/fast-deep-equal": ["fast-deep-equal@2.0.1", "", {}, "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="],
 

--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
   "dependencies": {
     "js-yaml": "^4.1.1"
   },
-  "optionalDependencies": {
-    "@tikoci/quickchr": "file:../quickchr"
-  },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
     "@biomejs/biome": "^2.0.0",
+    "@tikoci/quickchr": "^0.4.7",
     "actionlint": "^2.0.6",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",

--- a/scripts/nightly-build.test.ts
+++ b/scripts/nightly-build.test.ts
@@ -118,11 +118,14 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
   });
 
   test("buildOutputSuffix is arch+phase aware and overridable", () => {
-    expect(buildOutputSuffix("x86", "all")).toBe("nightly-quickchr-x86");
-    expect(buildOutputSuffix("x86", "extra")).toBe("nightly-quickchr-x86");
-    expect(buildOutputSuffix("x86", "base")).toBe("nightly-quickchr-x86-base");
-    expect(buildOutputSuffix("arm64", "base")).toBe("nightly-quickchr-arm64-base");
-    expect(buildOutputSuffix("arm64", "all")).toBe("nightly-quickchr-arm64");
+    expect(buildOutputSuffix("x86", "all")).toBe("nightly-x86");
+    expect(buildOutputSuffix("x86", "extra")).toBe("nightly-x86");
+    expect(buildOutputSuffix("x86", "base")).toBe("nightly-x86-base");
+    expect(buildOutputSuffix("arm64", "base")).toBe("nightly-arm64-base");
+    expect(buildOutputSuffix("arm64", "all")).toBe("nightly-arm64");
+    // The harness name must never appear in a suffix — nightly.json provenance
+    // records outputSuffix and is published to docs/.
+    expect(buildOutputSuffix("arm64", "extra")).not.toContain("quickchr");
     expect(buildOutputSuffix("x86", "base", "custom")).toBe("custom");
     expect(buildOutputSuffix("x86", "extra", "x86")).toBe("x86");
   });
@@ -139,17 +142,17 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
 
   test("outs.find fix — phase suffix prevents collision when tmpDir holds two crawls", () => {
     // Simulates N4's one-boot/two-crawl tmpDir holding both files.
-    const outs = ["deep-inspect.nightly-quickchr-x86-base.json", "deep-inspect.nightly-quickchr-x86.json", "nightly.json"];
+    const outs = ["deep-inspect.nightly-x86-base.json", "deep-inspect.nightly-x86.json", "nightly.json"];
     const baseSuffix = buildOutputSuffix("x86", "base");
     const extraSuffix = buildOutputSuffix("x86", "extra");
     const expectedBase = `deep-inspect.${baseSuffix}.json`;
     const expectedExtra = `deep-inspect.${extraSuffix}.json`;
-    expect(expectedBase).toBe("deep-inspect.nightly-quickchr-x86-base.json");
-    expect(expectedExtra).toBe("deep-inspect.nightly-quickchr-x86.json");
+    expect(expectedBase).toBe("deep-inspect.nightly-x86-base.json");
+    expect(expectedExtra).toBe("deep-inspect.nightly-x86.json");
     expect(outs.includes(expectedBase)).toBe(true);
     expect(outs.includes(expectedExtra)).toBe(true);
     // Old code: outs.find(f => f.startsWith("deep-inspect.")) → ambiguous (always picks first)
-    expect(outs.find((f) => f.startsWith("deep-inspect."))).toBe("deep-inspect.nightly-quickchr-x86-base.json");
+    expect(outs.find((f) => f.startsWith("deep-inspect."))).toBe("deep-inspect.nightly-x86-base.json");
     // New logic: exact match only
     expect(outs.includes(expectedBase) ? expectedBase : undefined).toBe(expectedBase);
     expect(outs.includes(expectedExtra) ? expectedExtra : undefined).toBe(expectedExtra);
@@ -158,13 +161,13 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
   test("exact-match gate does not validate wrong phase when expected output missing", () => {
     // Regression for coderabbit 3778267083: if extra output is absent but base
     // output exists, the gate must not fall back to the base file.
-    const outsOnlyBase = ["deep-inspect.nightly-quickchr-x86-base.json", "nightly.json"];
+    const outsOnlyBase = ["deep-inspect.nightly-x86-base.json", "nightly.json"];
     const extraSuffix = buildOutputSuffix("x86", "extra");
     const expectedExtra = `deep-inspect.${extraSuffix}.json`;
     const deepFile = outsOnlyBase.includes(expectedExtra) ? expectedExtra : undefined;
     expect(deepFile).toBeUndefined();
     // And vice versa: only extra present, asking for base should miss
-    const outsOnlyExtra = ["deep-inspect.nightly-quickchr-x86.json", "nightly.json"];
+    const outsOnlyExtra = ["deep-inspect.nightly-x86.json", "nightly.json"];
     const baseSuffix = buildOutputSuffix("x86", "base");
     const expectedBase = `deep-inspect.${baseSuffix}.json`;
     const deepFileBase = outsOnlyExtra.includes(expectedBase) ? expectedBase : undefined;

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -83,6 +83,7 @@ const { values } = parseArgs({
     arch: { type: "string", default: "x86" },
     phase: { type: "string", default: "all" },
     "base-version": { type: "string" },
+    "nightly-version": { type: "string" },
     channel: { type: "string", default: "stable" },
     "keep-running": { type: "boolean", default: false },
     "skip-collect": { type: "boolean", default: false },
@@ -117,6 +118,10 @@ Options:
                             Pinned to stable for nightly promotion; overridden by
                             --base-version.
   --base-version <ver>      Pin to an explicit RouterOS version instead of channel.
+  --nightly-version <ver>   Pin to a specific nightly version (e.g. 7.25_ab434).
+                            When set, the build uses that Box version instead of
+                            the latest discovered. Required in CI to pin all
+                            phases/jobs to the version from the discover job.
   --skip-collect            Skip heavy collection (rest2raml crawl + deep-inspect).
                             Does only shallow probes: /system/resource, /system/package,
                             /console/inspect child count. Aliases: --skip-crawl,
@@ -154,6 +159,10 @@ const PHASE = (() => {
 })();
 
 const BASE_VERSION: string | undefined = values["base-version"] as string | undefined;
+const PINNED_NIGHTLY_VERSION: string | undefined = values["nightly-version"] as string | undefined;
+if (PINNED_NIGHTLY_VERSION && !parseAb(PINNED_NIGHTLY_VERSION)) {
+  fail(`--nightly-version must be a nightly version like 7.25_ab434; got "${PINNED_NIGHTLY_VERSION}"`);
+}
 const CHANNEL = (values.channel as string) ?? "stable";
 const KEEP_RUNNING = Boolean(values["keep-running"]);
 const SKIP_COLLECT =
@@ -263,10 +272,10 @@ export function buildOutputSuffix(arch: Arch, phase: Phase, customSuffix?: strin
   return base;
 }
 
-async function discoverNightly(arch: Arch): Promise<{ version: string; files: string[]; allFiles: string[]; token: string; resolvedFrom: "302" | "pinned"; dirents: Array<{ file_name: string; size?: number; last_modified?: string }>; npks: Array<{ file: string; size: number | null; lastModified: string | null }>; rejected: string[]; buildWindow: { earliest: string; latest: string } | null }> {
+async function discoverNightly(arch: Arch, pinVersion?: string): Promise<{ version: string; files: string[]; allFiles: string[]; token: string; resolvedFrom: "302" | "pinned"; dirents: Array<{ file_name: string; size?: number; last_modified?: string }>; npks: Array<{ file: string; size: number | null; lastModified: string | null }>; rejected: string[]; buildWindow: { earliest: string; latest: string } | null }> {
   const { token, resolvedFrom } = await resolveToken();
   const apiUrl = boxApiUrl(token);
-  log(`→ discovering nightly via Box API ${apiUrl} (arch=${arch})`);
+  log(`→ discovering nightly via Box API ${apiUrl} (arch=${arch}${pinVersion ? ` pin=${pinVersion}` : ""})`);
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), 15_000);
   let res: Response;
@@ -282,9 +291,17 @@ async function discoverNightly(arch: Arch): Promise<{ version: string; files: st
   const nightlyRe = /(\d+\.\d+(?:\.\d+)?_ab\d+)/;
   const versions = [...new Set(allFiles.map((f) => f.match(nightlyRe)?.[1]).filter(Boolean))] as string[];
   if (versions.length === 0) fail("no nightly version found in Box dirent list");
-  const nightlyVer = [...versions].sort(compareAb).at(-1);
+  let nightlyVer: string | undefined;
+  if (pinVersion) {
+    if (!versions.includes(pinVersion)) fail(`pinned nightly version ${pinVersion} not found in Box dirent list (available: ${versions.join(", ")})`);
+    nightlyVer = pinVersion;
+    log(`  Box dirents: ${allFiles.length} files; nightly versions: ${versions.join(", ")} → pinned ${nightlyVer}`);
+  } else {
+    nightlyVer = [...versions].sort(compareAb).at(-1);
+    if (!nightlyVer) fail("no nightly version found in Box dirent list");
+    log(`  Box dirents: ${allFiles.length} files; nightly versions: ${versions.join(", ")} → latest ${nightlyVer}`);
+  }
   if (!nightlyVer) fail("no nightly version found in Box dirent list");
-  log(`  Box dirents: ${allFiles.length} files; nightly versions: ${versions.join(", ")} → latest ${nightlyVer}`);
   const files = filterNpksByArch(allFiles, nightlyVer, arch);
   const rawRejected = allFiles.filter((f) => f.includes(nightlyVer) && !files.includes(f));
   // Narrow to plausible rejects (the one that actually matters for the bug is the generic routeros duplicate)
@@ -345,7 +362,7 @@ async function downloadNpks(files: string[], dir: string, token: string) {
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
-  const { version: nightlyVer, files: archFiles, token: nightlyToken, resolvedFrom: nightlyResolvedFrom, dirents: nightlyDirents, npks: nightlyNpks, rejected: nightlyRejected, buildWindow: nightlyBuildWindow } = await discoverNightly(ARCH);
+  const { version: nightlyVer, files: archFiles, token: nightlyToken, resolvedFrom: nightlyResolvedFrom, dirents: nightlyDirents, npks: nightlyNpks, rejected: nightlyRejected, buildWindow: nightlyBuildWindow } = await discoverNightly(ARCH, PINNED_NIGHTLY_VERSION);
   const phaseFiles = getNpksForPhase(archFiles, PHASE);
   const outputSuffix = buildOutputSuffix(ARCH, PHASE, values["output-suffix"] as string | undefined);
   if (phaseFiles.length === 0) fail(`no ${ARCH} NPKs for phase ${PHASE} (arch filter yielded ${archFiles.length} before phase filter)`);
@@ -581,7 +598,6 @@ async function main() {
       outputSuffix,
       source: {
         shortUrl: MT_LV_URL,
-        token: nightlyToken,
         resolvedFrom: nightlyResolvedFrom,
         dirents: nightlyDirents.length,
       },

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -594,6 +594,8 @@ async function main() {
         allArchCount: nightlyNpks.length,
         rejected: nightlyRejected,
       },
+      // Roots nightly can never supply (Box share has no NPKs for these) — see #90 §1.2
+      absentRoots: ["dude", "openflow", "tr069-client", "user-manager"],
     };
     try {
       writeFileSync(join(tmpDir, "nightly.json"), JSON.stringify(nightlyProvenance, null, 2) + "\n");
@@ -666,6 +668,23 @@ async function main() {
           log(`    stat ${a} failed: ${String(e).slice(0, 200)}`);
         }
       }
+      // Stage rest2raml outputs into tmpDir with stable names so the
+      // workflow can collect per-phase artifacts without root collisions.
+      // Each --phase run gets its own tmpDir, so base and extra do not overwrite.
+      try {
+        const inspectSrc = join(repoRootArtifacts, "ros-inspect-all.json");
+        const ramlSrc = join(repoRootArtifacts, "ros-rest-all.raml");
+        if (existsSync(inspectSrc)) {
+          await Bun.write(join(tmpDir, "inspect.json"), Bun.file(inspectSrc));
+          log(`  staged → ${join(tmpDir, "inspect.json")}`);
+        }
+        if (existsSync(ramlSrc)) {
+          await Bun.write(join(tmpDir, "schema.raml"), Bun.file(ramlSrc));
+          log(`  staged → ${join(tmpDir, "schema.raml")}`);
+        }
+      } catch (e) {
+        log(`  stage rest2raml outputs failed: ${String(e).slice(0, 300)}`);
+      }
     }
 
     log(`\n→ running deep-inspect (enrichment) — can take minutes${IS_CROSS_ARCH ? " [longer under TCG]" : ""}`);
@@ -730,6 +749,39 @@ async function main() {
         } catch (e) {
           if (e instanceof Error && e.message.includes("deep-inspect argsTotal")) throw e;
           log(`  argsTotal check failed: ${String(e).slice(0, 300)}`);
+        }
+        // Stage OpenAPI with stable name for publish; deep-inspect already wrote
+        // openapi.<suffix>.json — copy to openapi.json in the same tmpDir.
+        try {
+          const openapiSuffixed = join(tmpDir, `openapi.${outputSuffix}.json`);
+          const openapiStable = join(tmpDir, "openapi.json");
+          if (existsSync(openapiSuffixed) && !existsSync(openapiStable)) {
+            await Bun.write(openapiStable, Bun.file(openapiSuffixed));
+            log(`  staged → ${openapiStable}`);
+          }
+        } catch (e) {
+          log(`  stage openapi failed: ${String(e).slice(0, 300)}`);
+        }
+        // Fetch /app for extra phases (container package present in nightly 5/9 set).
+        // Base phase has no container — skip. On 404/400 skip quietly (pre-7.22).
+        if (PHASE !== "base") {
+          try {
+            const appData: unknown = await chr.rest("/app");
+            if (Array.isArray(appData)) {
+              const dest = join(tmpDir, "app.json");
+              writeFileSync(dest, JSON.stringify(appData, null, 2) + "\n");
+              log(`  /app → ${dest} (${(appData as unknown[]).length} entries)`);
+            } else {
+              log(`  /app returned non-array: ${JSON.stringify(appData).slice(0, 300)}`);
+            }
+          } catch (e) {
+            const msg = String(e);
+            if (msg.includes("404") || msg.includes("400") || msg.includes("Not Found")) {
+              log(`  /app not available on this build (skip): ${msg.slice(0, 300)}`);
+            } else {
+              log(`  /app fetch failed (warn, not fatal): ${msg.slice(0, 500)}`);
+            }
+          }
         }
       }
     }

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -5,8 +5,9 @@
  * Boots a stable CHR via @tikoci/quickchr, discovers the current nightly
  * (mt.lv Box), downloads arch-specific NPKs, uploads via quickchr SCP,
  * reboots, and validates the version moves to the nightly build.
- * Single-slot `docs/nightly/` shape per #90 §6; one boot / two crawls
- * (base then extra) will be driven with --phase in N4.
+ * Single-slot `docs/nightly/` shape per #90 §6. `.github/workflows/nightly.yaml`
+ * drives this once per phase — a fresh CHR per `--phase`, each with its own
+ * `--output-dir`, rather than one boot with two crawls.
  *
  * Now arch-aware and CI-hardened:
  *   - `--arch x86|arm64` — x86 uses HVF on Intel, arm64 uses TCG (slow but viable)
@@ -127,11 +128,11 @@ Options:
                             /console/inspect child count. Aliases: --skip-crawl,
                             --skip-deep-inspect. Recommended for arm64/TCG.
   --output-dir <dir>        Where to write deep-inspect outputs when not skipped
-                            (default: mkdtemp nightly-quickchr-<ver>-<arch>-XXXXXX, or --output-dir to reuse).
+                            (default: mkdtemp nightly-<ver>-<arch>-XXXXXX, or --output-dir to reuse).
   --output-suffix <str>     Override deep-inspect output suffix (default:
-                            nightly-quickchr-<arch>[-<phase>]).
+                            nightly-<arch>[-<phase>]).
   --machine-name <name>     Override quickchr machine name (default:
-                            restraml-nightly-quickchr-<arch>).
+                            restraml-nightly-<arch>).
   --keep-running            Leave CHR running after the run (for manual inspection).
   --dry-run                 Discover nightly + filter per-arch NPKs and exit (no QEMU).
   --help                    Show this help.
@@ -170,7 +171,7 @@ const SKIP_COLLECT =
 // cross-arch on this host = TCG = slower reboot/probe windows
 const NATIVE_HOST_ARCH: Record<Arch, string> = { x86: "x64", arm64: "arm64" };
 const IS_CROSS_ARCH = process.arch !== NATIVE_HOST_ARCH[ARCH];
-const MACHINE_NAME = (values["machine-name"] as string | undefined) ?? `restraml-nightly-quickchr-${ARCH}`;
+const MACHINE_NAME = (values["machine-name"] as string | undefined) ?? `restraml-nightly-${ARCH}`;
 const EXTRA_TIMEOUT_MS = IS_CROSS_ARCH ? 120_000 : 0; // extra headroom for TCG reboots
 
 function formatBytes(n: number): string {
@@ -223,10 +224,10 @@ export function compareAb(a: string, b: string): number {
 }
 
 export function getNpksForPhase(allArchNpks: string[], phase: Phase): string[] {
-  // base → routeros-* only (1 NPK); extra/all → full arch set (5 or 9)
-  // For N4's one-boot/two-crawls, N4 will call base then extra against the same
-  // CHR via two workflow steps; isolated extra=all (full set) remains valid as a
-  // standalone full upgrade, while phase-aware floors keep base from failing.
+  // base → routeros-* only (1 NPK); extra/all → full arch set (5 or 9).
+  // nightly.yaml runs base and extra as separate steps against separate CHRs, so
+  // extra=all (full set) is always a standalone full upgrade; the phase-aware
+  // floors are what keep the smaller base crawl from failing the extra gate.
   if (phase === "base") return allArchNpks.filter((f) => f.toLowerCase().startsWith("routeros-"));
   return allArchNpks;
 }
@@ -264,7 +265,9 @@ export function buildOutputSuffix(arch: Arch, phase: Phase, customSuffix?: strin
     }
     return customSuffix;
   }
-  const base = `nightly-quickchr-${arch}`;
+  // Suffix names the *artifact* (arch/phase), never the harness — nightly.json
+  // provenance is published to docs/, so "quickchr" must not leak into it.
+  const base = `nightly-${arch}`;
   if (phase !== "all" && phase !== "extra") return `${base}-${phase}`;
   // extra and all both mean full set — keep suffix stable (no -extra) so existing
   // single-crawl consumers keep the same file names; N4 can pass explicit
@@ -372,10 +375,15 @@ async function main() {
       mkdirSync(custom, { recursive: true });
       return custom;
     }
-    return mkdtempSync(join(tmpdir(), `nightly-quickchr-${nightlyVer}-${ARCH}-`));
+    return mkdtempSync(join(tmpdir(), `nightly-${nightlyVer}-${ARCH}-`));
   })();
 
   if (values["dry-run"]) {
+    // Stable, machine-readable marker for CI discovery. Do not remove or reword:
+    // .github/workflows/nightly.yaml greps `^nightly-version=` for this exact line.
+    // Scraping prose instead would pick the wrong version whenever the Box share
+    // holds two ab builds during the upload window (the log lists all of them).
+    log(`nightly-version=${nightlyVer}`);
     log(`\n--dry-run: would download ${phaseFiles.length} ${ARCH} NPK(s) for ${nightlyVer} [phase=${PHASE}, suffix=${outputSuffix}] to ${join(tmpDir, "npks")}`);
     for (const f of phaseFiles) log(`  ${f}`);
     if (PHASE !== "all") log(`  (all for ${ARCH}: ${archFiles.join(", ")})`);


### PR DESCRIPTION
Implements the nightly single-slot build (§6) as a standalone `nightly.yaml` — the 40-min-failure-proof piece.

**Discover (hard no-op):** `302` via `mt.lv/nightly-build` → token fallback `5ce46054d5d2487e8755` → `GET /api/v2.1/share-links/{token}/dirents` → numeric `_ab` max via production `compareAb` (lexicographic bug covered), `3×` retry, soft `exit 0` on probe failure so `auto.yaml` not blocked; `changed` vs `docs/nightly/nightly.json:nightlyVersion`; `force`/`nightly_version` override via `workflow_dispatch`.

**Per-arch builds (simpler = two boots per x86):**
- `x86` `ubuntu-latest` `qemu-system-x86 + KVM 1024M 180s` → `nightly-build.ts --arch x86 --phase base --output-dir /tmp/nightly-x86-base --output-suffix nightly-quickchr-x86-base` (1 NPK, `1≥1` pkgs, `28k≥25k` floor) then `--phase extra` (5 NPKs, `5≥5`, `33k≥33k`) each fresh CHR; `180s+120s` extra headroom is not needed for native.
- `arm64` `ubuntu-24.04-arm` `qemu-system-arm + probe KVM/TCG 1024M 420s` → `phase extra` only (9 NPKs, `9≥9`, `34k≥34k`; base is canonical x86 base). Three boots total ≈ 20 min wall parallel (`40m/60m` timeouts).

**Why quickchr, why separate tmpDirs:** `filterNpksByArch()` (generic `routeros-*.npk` duplicate that bricked the first `ab431` run) stays single-sourced — not reimplemented in bash. Per-phase `--output-dir` avoids `ros-*` root collisions and `deep-inspect.<suffix>.json` exact gate (no `startsWith` fallback) prevents validating the wrong phase when `tmpDir` holds two crawls. Staged into `tmpDir/inspect.json|schema.raml|openapi.json` + `deep-inspect.<suffix>.json` + nightly `app.json` (extra only, `404` warn, validated against `routeros-app-yaml-schema.latest.json` meta only, not per-version).

**Publish (single `docs/nightly/` overwritten slot):**
- `x86 base → docs/nightly/{inspect, schema, openapi, deep-inspect.json}` (canonical base)
- `x86 extra → docs/nightly/extra/{inspect, schema, openapi, deep-inspect.x86.json, app.json}`
- `arm64 extra → docs/nightly/extra/deep-inspect.arm64.json`
- `diff-deep-inspect.json` `x86 extra vs arm64 extra` (`≥500` arm64-only paths gate catches relabeled x86)
- `nightly.json` §6 aggregated: `nightlyVersion` max `compareAb`, `builtAt` publish time, `buildWindow` `earliest=min latest=max` from dirents, `packages.{x86,arm64}`, `rejected` plausible duplicate, `absentRoots:[dude,openflow,tr069-client,user-manager]` (Box has no NPKs for these, 2,325-node diff would otherwise mislead), full `provenance.{x86,arm64}`.
- `bun scripts/build-docs-index.mjs` → `latestVersion` stays real release, `nightly:{name,nightlyVersion,builtAt}` sibling; `openapi.html` needs no change (file-presence).

**Grounding:** `228 pass / 740 expects`, `tsc 0`, `biome 0`, `actionlint 9 files pass`, `build-docs-index` `latestVersion 7.24rc4` not `nightly`, dry-run `7.25_ab434` `5/9` split verified (`routeros-x86` vs `routeros-arm64` + 4 wifi/zerotier, generic duplicate rejected).

N5 (changelog synth `404`, range exclusion, MIB `404`, nightly badge `abNNN`+age, `?nightly=true`) and N6 (`/app` `--no-schema-write`) remain deferred per §3/§4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated nightly documentation builds with scheduled and manual запуск options.
  - Added x86 and ARM64 documentation outputs, including architecture comparisons.
  - Added consolidated documentation publishing with updated indexes and downloadable build artifacts.
  - Added provenance details and optional application metadata to generated documentation.
- **Bug Fixes**
  - Improved handling of unavailable nightly sources and unsupported metadata endpoints without interrupting builds.
  - Added artifact validation and retry support for more reliable publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->