### PR TITLE
deep-inspect: surface crawl failures and per-root census (#96)

### DIFF
--- a/.github/workflows/deep-inspect-multi-arch.yaml
+++ b/.github/workflows/deep-inspect-multi-arch.yaml
@@ -188,6 +188,10 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Run deep-inspect (x86, live crawl + enrichment)
+        # deep-inspect.ts may exit 2 on crawl truncation (crawlStats; see #97).
+        # This workflow invokes deep-inspect.ts directly, not
+        # scripts/deep-inspect-multi-arch.ts, so exit-2 upload handling is
+        # workflow-local (if: always() on Upload) until harnesses converge.
         run: |
           bun deep-inspect.ts --live --arch x86 --output-suffix x86 \
             --output-dir . --skip-openapi --test-crash-paths --transport rest
@@ -203,6 +207,7 @@ jobs:
           echo "✓ x86 argsTotal=$ARGS_TOTAL (≥30000)"
 
       - name: Upload deep-inspect.x86.json
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: deep-inspect-x86
@@ -450,6 +455,10 @@ jobs:
         # TCG per-request timeout: 120s (generous margin over measured ~70ms;
         # handles occasional slow calls without masking real failures).
         # KVM: 30s is sufficient.
+        # Note: deep-inspect.ts may exit 2 on crawl truncation (crawlStats; see #97).
+        # This workflow invokes deep-inspect.ts directly — exit-2 upload handling is
+        # workflow-local (if: always() on Upload) until harnesses converge with
+        # scripts/deep-inspect-multi-arch.ts.
         run: |
           if [ "${ARM_ACCEL}" = "kvm" ]; then REQ_TIMEOUT=30000; else REQ_TIMEOUT=120000; fi
           bun deep-inspect.ts --live --arch arm64 --output-suffix arm64 \
@@ -467,6 +476,7 @@ jobs:
           echo "✓ arm64 argsTotal=$ARGS_TOTAL (≥30000)"
 
       - name: Upload deep-inspect.arm64.json
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: deep-inspect-arm64

--- a/deep-inspect.ts
+++ b/deep-inspect.ts
@@ -52,6 +52,22 @@ export interface DeepInspectMeta {
      *  These are "silent misses" that should never differ from the REST transport. */
     argsBlankOnRetry: number;
   };
+  /** Crawl-stage observability — tracks REST `fetchChild` failures that previously
+   *  silently shrank `argsTotal` (see #96). A non-zero `pathsFailed` means subtrees
+   *  were dropped; the run should be treated as incomplete. Per-root `census` lets a
+   *  shortfall point at which subtree vanished. */
+  crawlStats?: {
+    /** Number of paths whose `fetchChild` errored or timed out (AbortSignal.timeout). */
+    pathsFailed: number;
+    /** First up to 50 failed path strings (e.g. "/ip/address") for diagnosis. */
+    failedPaths: string[];
+    /** Optional total of paths that were successfully crawled (includes dirs). */
+    pathsVisited?: number;
+  };
+  /** Per top-level root (first path segment) arg count census — e.g. { "ip": 4231 }.
+   *  Derived from the crawled tree before enrichment. Lets a total shortfall (e.g.
+   *  36793 → 28748) point at which subtree disappeared. See scripts/census.mjs. */
+  census?: Record<string, number>;
   /** Present only when native transport was used. Tracks TCP connection resets
    *  observed during enrichment — each reset rejects all in-flight commands on the
    *  shared connection. Non-zero values indicate a potential RouterOS or Bun bug
@@ -545,12 +561,19 @@ export function setCrawlRequestTimeout(ms: number | undefined) {
   CRAWL_REQUEST_TIMEOUT_MS = ms;
 }
 
-/** Crawl the inspect tree from scratch via the live router (mirrors rest2raml.js parseChildren) */
+/** Crawl the inspect tree from scratch via the live router (mirrors rest2raml.js parseChildren)
+ *
+ *  Failures are tracked rather than thrown so a single flaky REST call does
+ *  not abort the entire multi-thousand-path crawl, but they are recorded
+ *  in `crawlFailures` (and surfaced in `_meta.crawlStats`) so CI can treat
+ *  any failure as a hard error instead of silently shrinking `argsTotal` (#96).
+ */
 export async function crawlInspectTree(
   client: IRouterOSClient,
   rpath: string[] = [],
   skipPaths: Set<string> = new Set(CRASH_PATHS as unknown as string[]),
   _depth = 0,
+  crawlFailures?: string[],
 ): Promise<InspectNode> {
   const memo: InspectNode = {};
   const signal = CRAWL_REQUEST_TIMEOUT_MS ? AbortSignal.timeout(CRAWL_REQUEST_TIMEOUT_MS) : undefined;
@@ -558,7 +581,11 @@ export async function crawlInspectTree(
   try {
     children = await client.fetchChild(rpath, signal);
   } catch (err) {
-    const pathStr = `/${rpath.join("/")}`;
+    const pathStr = `/${rpath.join("/")}` || "/";
+    if (crawlFailures) {
+      if (crawlFailures.length < 50) crawlFailures.push(pathStr);
+      // count overflow beyond 50 as extra without storing each string
+    }
     console.error(`  ⚠ fetchChild failed for ${pathStr}: ${err instanceof Error ? err.message : err}`);
     return memo;
   }
@@ -591,15 +618,38 @@ export async function crawlInspectTree(
     }
 
     try {
-      const childTree = await crawlInspectTree(client, newpath, skipPaths, _depth + 1);
+      const childTree = await crawlInspectTree(client, newpath, skipPaths, _depth + 1, crawlFailures);
       Object.assign(node, childTree);
     } catch (err) {
       const pathStr = `/${newpath.join("/")}`;
+      if (crawlFailures && crawlFailures.length < 50) crawlFailures.push(pathStr);
       console.error(`  ⚠ crawl failed for ${pathStr}: ${err instanceof Error ? err.message : err}`);
     }
   }
 
   return memo;
+}
+
+/** Build a per top-level root arg census from a crawled tree.
+ *  Mirrors scripts/census.mjs / /tmp/repro-96/census.mjs for in-process use. */
+export function buildCensus(tree: InspectNode): Record<string, number> {
+  function countArgs(node: InspectNode): number {
+    let n = 0;
+    for (const [k, v] of Object.entries(node)) {
+      if (k.startsWith("_") || typeof v !== "object" || v === null) continue;
+      const child = v as InspectNode;
+      if (child._type === "arg") n++;
+      n += countArgs(child);
+    }
+    return n;
+  }
+  const census: Record<string, number> = {};
+  for (const [k, v] of Object.entries(tree)) {
+    if (k.startsWith("_")) continue;
+    if (!v || typeof v !== "object") continue;
+    census[k] = countArgs(v as InspectNode);
+  }
+  return census;
 }
 
 // ── OpenAPI 3.0 Generation ─────────────────────────────────────────────────
@@ -1266,6 +1316,7 @@ async function main() {
   // Load or crawl the inspect tree
   let inspectTree: InspectNode;
   let version = "unknown";
+  const crawlFailures: string[] = [];
 
   if (opts.live) {
     if (!client) {
@@ -1287,7 +1338,12 @@ async function main() {
       }
     }
 
-    inspectTree = await crawlInspectTree(client, pathArgs, skipPaths);
+    inspectTree = await crawlInspectTree(client, pathArgs, skipPaths, 0, crawlFailures);
+    if (crawlFailures.length > 0) {
+      console.error(`\n⚠ Crawl had ${crawlFailures.length} fetchChild failure(s) — subtrees were dropped:`);
+      for (const p of crawlFailures) console.error(`    ${p}`);
+      console.error("  → _meta.crawlStats records this. Treat as a failed crawl (#96).");
+    }
   } else if (opts.inspectFile) {
     const file = Bun.file(opts.inspectFile);
     if (!(await file.exists())) {
@@ -1313,6 +1369,15 @@ async function main() {
   }
 
   console.log(`Version: ${version}`);
+
+  // Build census immediately after crawl so a shortfall is diagnosable even
+  // before enrichment. For --inspect-file, census is just derived from the file.
+  const census = buildCensus(inspectTree);
+  if (opts.live) {
+    const top3 = Object.entries(census).sort((a, b) => b[1] - a[1]).slice(0, 5)
+      .map(([k, v]) => `/${k}=${v}`).join(", ");
+    console.log(`Census (top roots): ${top3 || "<empty>"}`);
+  }
 
   // Test CRASH_PATHS (if requested and not already done in --live mode)
   let crashPathResults: CrashPathResult[] = [];
@@ -1358,6 +1423,13 @@ async function main() {
     crashPathsSafe: crashPathResults.filter((r) => r.safe).map((r) => r.path),
     crashPathsCrashed: crashPathResults.filter((r) => !r.safe).map((r) => r.path),
     completionStats,
+    // Crawl-stage failures: previously silent shrinkage of argsTotal is now
+    // visible and checked by CI/orchestrator. Empty array = healthy crawl.
+    crawlStats: {
+      pathsFailed: crawlFailures.length,
+      failedPaths: crawlFailures.slice(0, 50),
+    },
+    census,
   };
 
   // Attach native API reconnect diagnostics when present.
@@ -1394,6 +1466,15 @@ async function main() {
 
   // Close native API connection if open
   client?.close?.();
+
+  // Fail loudly on crawl-stage truncation (#96) — a dropped subtree must
+  // not be mistaken for a small upstream delta. The written _meta.crawlStats
+  // preserves diagnostics for the artifact.
+  if (crawlFailures.length > 0) {
+    console.error(`\n✗ Crawl incomplete: ${crawlFailures.length} path(s) failed (see _meta.crawlStats.failedPaths).`);
+    console.error("  → NOT a schema delta — investigate REST/timeout/harness before merging.");
+    process.exit(2);
+  }
 }
 
 // Only run main when executed directly (not imported in tests)

--- a/deep-inspect.ts
+++ b/deep-inspect.ts
@@ -61,8 +61,6 @@ export interface DeepInspectMeta {
     pathsFailed: number;
     /** First up to 50 failed path strings (e.g. "/ip/address") for diagnosis. */
     failedPaths: string[];
-    /** Optional total of paths that were successfully crawled (includes dirs). */
-    pathsVisited?: number;
   };
   /** Per top-level root (first path segment) arg count census — e.g. { "ip": 4231 }.
    *  Derived from the crawled tree before enrichment. Lets a total shortfall (e.g.
@@ -593,7 +591,7 @@ export async function crawlInspectTree(
   try {
     children = await client.fetchChild(rpath, signal);
   } catch (err) {
-    const pathStr = `/${rpath.join("/")}` || "/";
+    const pathStr = `/${rpath.join("/")}`;
     recordCrawlFailure(crawlFailures, pathStr);
     console.error(`  ⚠ fetchChild failed for ${pathStr}: ${err instanceof Error ? err.message : err}`);
     return memo;

--- a/deep-inspect.ts
+++ b/deep-inspect.ts
@@ -568,12 +568,24 @@ export function setCrawlRequestTimeout(ms: number | undefined) {
  *  in `crawlFailures` (and surfaced in `_meta.crawlStats`) so CI can treat
  *  any failure as a hard error instead of silently shrinking `argsTotal` (#96).
  */
+export interface CrawlFailures {
+  count: number;
+  /** Sample of failed path strings, capped at 50 for _meta.crawlStats.failedPaths. */
+  paths: string[];
+}
+
+export function recordCrawlFailure(failures: CrawlFailures | undefined, path: string): void {
+  if (!failures) return;
+  failures.count++;
+  if (failures.paths.length < 50) failures.paths.push(path);
+}
+
 export async function crawlInspectTree(
   client: IRouterOSClient,
   rpath: string[] = [],
   skipPaths: Set<string> = new Set(CRASH_PATHS as unknown as string[]),
   _depth = 0,
-  crawlFailures?: string[],
+  crawlFailures?: CrawlFailures,
 ): Promise<InspectNode> {
   const memo: InspectNode = {};
   const signal = CRAWL_REQUEST_TIMEOUT_MS ? AbortSignal.timeout(CRAWL_REQUEST_TIMEOUT_MS) : undefined;
@@ -582,10 +594,7 @@ export async function crawlInspectTree(
     children = await client.fetchChild(rpath, signal);
   } catch (err) {
     const pathStr = `/${rpath.join("/")}` || "/";
-    if (crawlFailures) {
-      if (crawlFailures.length < 50) crawlFailures.push(pathStr);
-      // count overflow beyond 50 as extra without storing each string
-    }
+    recordCrawlFailure(crawlFailures, pathStr);
     console.error(`  ⚠ fetchChild failed for ${pathStr}: ${err instanceof Error ? err.message : err}`);
     return memo;
   }
@@ -622,7 +631,7 @@ export async function crawlInspectTree(
       Object.assign(node, childTree);
     } catch (err) {
       const pathStr = `/${newpath.join("/")}`;
-      if (crawlFailures && crawlFailures.length < 50) crawlFailures.push(pathStr);
+      recordCrawlFailure(crawlFailures, pathStr);
       console.error(`  ⚠ crawl failed for ${pathStr}: ${err instanceof Error ? err.message : err}`);
     }
   }
@@ -1316,7 +1325,7 @@ async function main() {
   // Load or crawl the inspect tree
   let inspectTree: InspectNode;
   let version = "unknown";
-  const crawlFailures: string[] = [];
+  const crawlFailures: CrawlFailures = { count: 0, paths: [] };
 
   if (opts.live) {
     if (!client) {
@@ -1339,9 +1348,12 @@ async function main() {
     }
 
     inspectTree = await crawlInspectTree(client, pathArgs, skipPaths, 0, crawlFailures);
-    if (crawlFailures.length > 0) {
-      console.error(`\n⚠ Crawl had ${crawlFailures.length} fetchChild failure(s) — subtrees were dropped:`);
-      for (const p of crawlFailures) console.error(`    ${p}`);
+    if (crawlFailures.count > 0) {
+      console.error(`\n⚠ Crawl had ${crawlFailures.count} fetchChild failure(s) — subtrees were dropped:`);
+      for (const p of crawlFailures.paths) console.error(`    ${p}`);
+      if (crawlFailures.count > crawlFailures.paths.length) {
+        console.error(`    ...and ${crawlFailures.count - crawlFailures.paths.length} more (capped at 50 sampled)`);
+      }
       console.error("  → _meta.crawlStats records this. Treat as a failed crawl (#96).");
     }
   } else if (opts.inspectFile) {
@@ -1424,10 +1436,10 @@ async function main() {
     crashPathsCrashed: crashPathResults.filter((r) => !r.safe).map((r) => r.path),
     completionStats,
     // Crawl-stage failures: previously silent shrinkage of argsTotal is now
-    // visible and checked by CI/orchestrator. Empty array = healthy crawl.
+    // visible and checked by CI/orchestrator. Empty = healthy crawl.
     crawlStats: {
-      pathsFailed: crawlFailures.length,
-      failedPaths: crawlFailures.slice(0, 50),
+      pathsFailed: crawlFailures.count,
+      failedPaths: crawlFailures.paths.slice(0, 50),
     },
     census,
   };
@@ -1470,8 +1482,11 @@ async function main() {
   // Fail loudly on crawl-stage truncation (#96) — a dropped subtree must
   // not be mistaken for a small upstream delta. The written _meta.crawlStats
   // preserves diagnostics for the artifact.
-  if (crawlFailures.length > 0) {
-    console.error(`\n✗ Crawl incomplete: ${crawlFailures.length} path(s) failed (see _meta.crawlStats.failedPaths).`);
+  if (crawlFailures.count > 0) {
+    console.error(`\n✗ Crawl incomplete: ${crawlFailures.count} path(s) failed (see _meta.crawlStats.failedPaths).`);
+    if (crawlFailures.paths.length > 0) {
+      console.error(`  Sample: ${crawlFailures.paths.slice(0, 5).join(", ")}${crawlFailures.count > 5 ? " …" : ""}`);
+    }
     console.error("  → NOT a schema delta — investigate REST/timeout/harness before merging.");
     process.exit(2);
   }

--- a/docs/deep-inspect.schema.json
+++ b/docs/deep-inspect.schema.json
@@ -72,6 +72,12 @@
         "completionStats": {
           "$ref": "#/definitions/completionStats"
         },
+        "crawlStats": {
+          "$ref": "#/definitions/crawlStats"
+        },
+        "census": {
+          "$ref": "#/definitions/census"
+        },
         "nativeApiReconnects": {
           "$ref": "#/definitions/nativeApiReconnects"
         }
@@ -108,6 +114,34 @@
         }
       },
       "additionalProperties": false
+    },
+    "crawlStats": {
+      "type": "object",
+      "description": "Crawl-stage observability (see #96). Non-zero pathsFailed means subtrees were silently dropped previously — now surfaced. Max 50 failedPaths stored.",
+      "required": ["pathsFailed", "failedPaths"],
+      "properties": {
+        "pathsFailed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedPaths": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "pathsVisited": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "census": {
+      "type": "object",
+      "description": "Per top-level root arg count census (e.g. {\"ip\": 4231}). Lets a total shortfall point at which subtree vanished. Derived from crawled tree before enrichment.",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
     },
     "nativeApiReconnects": {
       "type": "object",

--- a/docs/deep-inspect.schema.json
+++ b/docs/deep-inspect.schema.json
@@ -126,6 +126,7 @@
         },
         "failedPaths": {
           "type": "array",
+          "maxItems": 50,
           "items": { "type": "string" }
         },
         "pathsVisited": {

--- a/docs/deep-inspect.schema.json
+++ b/docs/deep-inspect.schema.json
@@ -128,10 +128,6 @@
           "type": "array",
           "maxItems": 50,
           "items": { "type": "string" }
-        },
-        "pathsVisited": {
-          "type": "integer",
-          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/scripts/deep-inspect-multi-arch.ts
+++ b/scripts/deep-inspect-multi-arch.ts
@@ -139,6 +139,9 @@ interface ArchResult {
   argsTotal: number;
   argsWithCompletion: number;
   enrichmentDurationMs?: number;
+  crawlFailed: number;
+  crawlFailedPaths: string[];
+  census?: Record<string, number>;
 }
 
 async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
@@ -150,15 +153,37 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
   // boot timeout are handled inside quickchr based on cross-arch emulation
   // detection, so no manual bumping here. start() resolves REST-ready per its
   // docstring (all provisioning complete), so no belt-and-suspenders waitForBoot.
-  const chr = await QuickCHR.start({
-    arch,
-    channel: opts.channel,
-    version: opts.version,
-    installAllPackages: true,
-    secureLogin: false,
-    background: true,
-    license: "p1",
-  });
+  // If the MikroTik account has exhausted trials ("too many trial licences",
+  // seen since 2026-08-13), retry at free tier — the crawl is correct just slower.
+  let chr: Awaited<ReturnType<typeof QuickCHR.start>>;
+  try {
+    chr = await QuickCHR.start({
+      arch,
+      channel: opts.channel,
+      version: opts.version,
+      installAllPackages: true,
+      secureLogin: false,
+      background: true,
+      license: "p1",
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("too many trial licences")) {
+      console.warn(`⚠ License exhausted (${msg}) — retrying without license (free tier, 1 Mbit/s, slower but correct).`);
+      chr = await QuickCHR.start({
+        arch,
+        channel: opts.channel,
+        version: opts.version,
+        installAllPackages: true,
+        secureLogin: false,
+        background: true,
+        // no license field → free tier
+      });
+      console.warn(`✓ CHR ready at free tier (no p1) — continuing.`);
+    } else {
+      throw e;
+    }
+  }
 
   console.log(`CHR ready at ${chr.restUrl}`);
   console.log(`  ports: http=${chr.ports.http} ssh=${chr.ports.ssh} api=${chr.ports.api}`);
@@ -218,6 +243,11 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
         argsTimedOut: number;
         argsBlankOnRetry: number;
       };
+      crawlStats?: {
+        pathsFailed: number;
+        failedPaths: string[];
+      };
+      census?: Record<string, number>;
     };
   };
 
@@ -233,6 +263,9 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
     argsTotal: meta.completionStats.argsTotal,
     argsWithCompletion: meta.completionStats.argsWithCompletion,
     enrichmentDurationMs: meta.enrichmentDurationMs,
+    crawlFailed: meta.crawlStats?.pathsFailed ?? 0,
+    crawlFailedPaths: meta.crawlStats?.failedPaths ?? [],
+    census: meta.census,
   };
 
   // Sanity check that --arch threaded through correctly
@@ -262,15 +295,21 @@ function summarize(results: ArchResult[]): void {
   console.log("\n━━━ SUMMARY ━━━");
   for (const r of results) {
     const durS = r.enrichmentDurationMs ? `${(r.enrichmentDurationMs / 1000).toFixed(1)}s` : "?";
+    const crawlNote = r.crawlFailed > 0 ? `  ${r.crawlFailed} crawlFailed` : "";
     console.log(
       `  ${r.arch.padEnd(5)} v${r.version}  ` +
       `${r.argsWithCompletion}/${r.argsTotal} enriched  ` +
       `${r.argsFailed} failed  ${r.argsTimedOut} retried  ` +
       `${r.argsBlankOnRetry} blank-on-retry  ` +
-      `${r.crashPathsCrashed.length} crashed  ` +
+      `${r.crashPathsCrashed.length} crashed${crawlNote}  ` +
       `(${durS})`,
     );
     console.log(`         → ${r.deepInspectPath}`);
+    if (r.census) {
+      const top = Object.entries(r.census).sort((a, b) => b[1] - a[1]).slice(0, 3)
+        .map(([k, v]) => `/${k}=${v}`).join(", ");
+      if (top) console.log(`         census: ${top}`);
+    }
   }
 }
 
@@ -279,6 +318,18 @@ function checkAnomalies(results: ArchResult[]): boolean {
   // or failed arg is a signal worth investigating, not a thing to silently tolerate.
   let anomalies = false;
   for (const r of results) {
+    if (r.crawlFailed > 0) {
+      anomalies = true;
+      console.error(`\n⚠ ${r.arch}: ${r.crawlFailed} path(s) failed during crawl (fetchChild timeout/error) — subtrees dropped:`);
+      for (const p of r.crawlFailedPaths) console.error(`    ${p}`);
+      console.error(`  → This is NOT a small schema delta; it is a truncated crawl (#96).`);
+      console.error(`  See ${r.deepInspectPath} _meta.crawlStats and _meta.census for that run.`);
+      if (r.census) {
+        const sorted = Object.entries(r.census).sort((a, b) => b[1] - a[1]).slice(0, 5)
+          .map(([k, v]) => `/${k}=${v}`).join(", ");
+        console.error(`  Census top roots: ${sorted || "<empty>"}`);
+      }
+    }
     if (r.crashPathsCrashed.length > 0) {
       anomalies = true;
       console.error(`\n⚠ ${r.arch}: ${r.crashPathsCrashed.length} path(s) crashed during crawl:`);

--- a/scripts/deep-inspect-multi-arch.ts
+++ b/scripts/deep-inspect-multi-arch.ts
@@ -216,8 +216,15 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
   });
 
   const exitCode = await proc.exited;
-  if (exitCode !== 0) {
+  // deep-inspect.ts exits 2 for crawl-stage truncation (writes _meta.crawlStats
+  // before exiting). That is an incomplete artifact — we still want to read
+  // its _meta (so checkAnomalies can surface crawlFailed/census) and run
+  // chr.destroy() before failing. Only truly unexpected exits should throw here.
+  if (exitCode !== 0 && exitCode !== 2) {
     throw new Error(`${arch}: deep-inspect.ts exited with code ${exitCode}`);
+  }
+  if (exitCode === 2) {
+    console.warn(`⚠ ${arch}: deep-inspect.ts exited 2 (crawl incomplete) — reading _meta for diagnostics before cleanup.`);
   }
 
   // Post-crawl load snapshot (best-effort) — informational, not load-bearing.


### PR DESCRIPTION
Fixes the silent-truncation *class* that would have made #96's future recurrences report green until a 30k gate caught them 8k late.

## What this PR actually catches — and what it doesn't (per Opus review)

Local quickchr arm64-TCG repro against the exact failing version `7.24rc4` (free tier, 19 pkgs, same binary the CI job fails on) yields a *clean* tree identical to the last good `7.24rc2`:

```
7.24rc2 arm64: 36793 args, 48838 paths
7.24rc4 arm64: 36793 args, 48838 paths — 0 delta, 3 trivial enum drifts
```

Combined with the nightly control (`7.25_ab434` arm64-TCG quickchr, `34735` at a 34k floor, same `ubuntu-24.04-arm` runner family, also `free` and correct), this proved harness-specific, not upstream.

**But the failing run's log shows the instrumented path never fired:** `fetchChild` — 0 occurrences, `failed for` — 0, only `⚠` is the KVM/TCG notice in [run #31670987516](https://github.com/tikoci/restraml/actions/runs/31670987516). So `_meta.crawlStats.pathsFailed` would be `0` and `exit 2` would never fire — this PR **would not have caught #96**.

Opus's root-cause comment on #96 nails why: **86 roots on x86 vs 79 on arm64** — eight package-provided menus absent on arm64 despite being installed:

```
/app  /caps-man  /container  /dude  /iot  /openflow  /tr069-client  /user-manager
```

Package table from that run shows arm64 (19 pkgs) is a *superset* of x86 (13 pkgs), including every root it lacks. Install succeeded; activation didn't — the workflow's `List installed packages` step only prints `.name`, so the `≥10` gate passed while menus were inactive. The verifying query is `curl …/rest/system/package | jq '[.[] | {name, disabled, scheduled}]'` — which is not in CI today.

**What this PR *would* have caught is the census.** `buildCensus` reconciles exactly (`censusSum == argsTotal` verified on three published artifacts: 33685/34735/35656), so a missing root shows up as a missing key in `_meta.census`, not a vague total. That's the half that genuinely delivers.

## What this PR does

- **`deep-inspect.ts`**: track `fetchChild` failures in a counted sample (`CrawlFailures {count, paths: ≤50}` via `recordCrawlFailure()`), expose `_meta.crawlStats {pathsFailed, failedPaths}` and `_meta.census {root → argCount}` (via `buildCensus()`), log top roots, and `process.exit(2)` on any crawl failure so CI fails fast with diagnostics instead of publishing short. The written artifact is preserved for post-mortem. Closes off a real latent hazard (TCG REST timeout → empty subtree) even though it wasn't the #96 mechanism.
- **`scripts/deep-inspect-multi-arch.ts`**: on `ERROR: too many trial licences` (account exhausted since 2026-08-13 — nightly and this local repro prove `free` is correct, just slower: `552s/421s` enrichment at 1 Mbit/s) retry without `license:"p1"`; accept `exit 2` as a readable incomplete artifact (load `_meta` + `census`, run `chr.destroy()`, let `checkAnomalies` surface it). Surfaces `crawlStats`/`census` in summary and `checkAnomalies`.
- **`docs/deep-inspect.schema.json`**: allow optional `crawlStats` (with `maxItems:50`) and `census` (backward-compatible; old artifacts still validate).
- **`.github/workflows/deep-inspect-multi-arch.yaml`**: add `if: always()` to both `Upload deep-inspect.<arch>.json` steps so the new diagnostics leave the runner even when the crawl gate or the new `exit 2` fails the job; annotate that CI calls `deep-inspect.ts` directly (not the orchestrator) so exit-2 handling is workflow-local until harnesses converge. Removes dead `pathsVisited` field and unreachable `|| "/"` fallback.

## Why this Refs, not Closes, #96

This PR gives #96 the observability it asked for, but the activation bug is untouched — the arm64 job is still red on the same run, just earlier and louder. Keep #96 open until the package-activation check lands (see its comment for the `{name, disabled, scheduled}` query and the two gate follow-ups). Auto-closing would bury the real defect.

## Follow-up (second PR)

**Harness convergence**: `scripts/deep-inspect-multi-arch.ts` (local) already uses `@tikoci/quickchr`; `nightly.yaml` → `scripts/nightly-build.ts` also uses `quickchr` — both passed on `ubuntu-24.04-arm` TCG. `.github/workflows/deep-inspect-multi-arch.yaml` still does raw QEMU (`apt-get qemu-system-arm`, `wget …/chr-*.img.zip`, `qemu-system-aarch64 -M virt …`, `curl …/rest/execute` package-enable). The idea is to make the CI workflow use the same `quickchr` provisioning path, eliminating the divergent package-activation code that this bisection isolated. The 13-vs-19 package asymmetry between x86/arm64 and the `≥10` gate measuring presence not usability are part of that convergence.

*Downstream shape change*: `_meta.census`/`crawlStats` are additive + schema-guarded (like #85/#86) so rosetta won't break, but worth the same heads-up.

Refs #96

### Testing

- `bun test` — 228 pass
- `bun run lint` / `bunx tsc --noEmit` / `actionlint` — pass
- `buildCensus` verified against three published artifacts (exact match with `argsTotal`)
