### PR TITLE
Handle nightly gracefully across docs (N5) (#90)

### DIFF
--- a/docs/diff.html
+++ b/docs/diff.html
@@ -320,6 +320,10 @@
                         <input id="diffShowAll" type="checkbox" role="switch">
                         include <code>testing</code>
                     </label>
+                    <label class="ml-1">
+                        <input id="diffShowNightly" type="checkbox" role="switch">
+                        include <code>nightly</code>
+                    </label>
                 </ul>
             </nav>
 
@@ -488,6 +492,19 @@
                         most admins think in terminal.
                     </small>
                 </div>
+                <hr>
+                <div class="behind-curtain">
+                    <small>
+                        <b>Nightly note</b> &mdash; <code>nightly</code> is the single
+                        overwritten slot at <a href="https://mt.lv/nightly-build">mt.lv/nightly-build</a>
+                        (<code>docs/nightly/</code>, badge <code>nightly (7.25_ab434)</code> &middot; age).
+                        Its <code>extra/</code> is partial &mdash; no nightly NPKs exist for
+                        <code>dude</code>, <code>user-manager</code>, <code>openflow</code>,
+                        <code>tr069-client</code>, so a diff vs release extra shows those roots as
+                        &ldquo;removed&rdquo; &mdash; not a real removal, just absent from the Box share.
+                        See <code>nightly.json</code> for exact packages and build window.
+                    </small>
+                </div>
                 <footer>
                     <small>
                         💬 <a href="https://github.com/tikoci/restraml/issues/new/choose">Open an issue on GitHub</a>
@@ -582,6 +599,7 @@
         // All collected versions for diff dropdowns (sorted at insertion time)
         const _diffVersions = []
         let _diffShowAll = false
+        let _diffShowNightly = false
         const _changelogCache = {}
         let _loadedRangeSections = null
         let _loadedRangeKey = null
@@ -617,9 +635,14 @@
         }
 
         function getChangelogVersionsInRange(range) {
+            // Use shared helper which always excludes synthetic nightly (no CHANGELOG on download.mikrotik.com)
+            if (typeof window.getChangelogVersionsInRange === 'function' && window.getChangelogVersionsInRange.length === 3) {
+                // Shared helper is available (N5) — it already excludes nightly
+                return window.getChangelogVersionsInRange(range, _diffVersions, _diffShowAll)
+            }
             const candidateVersions = _diffShowAll
-                ? _diffVersions
-                : _diffVersions.filter(version => !isPreRelease(version))
+                ? _diffVersions.filter(v => !isNightly(v))
+                : _diffVersions.filter(v => !isNightly(v) && !isTestingPreRelease(v))
 
             return candidateVersions.filter(version => {
                 if (range.older === range.newer) return version === range.newer
@@ -694,6 +717,21 @@
         }
 
         async function fetchChangelogSectionsForVersion(version) {
+            if (isNightly(version)) {
+                // Synthetic section from nightly.json — shared helper handles caching
+                if (typeof window.fetchChangelogSectionsForVersion === 'function') {
+                    return window.fetchChangelogSectionsForVersion(version)
+                }
+                const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
+                if (nightlyData) return createNightlySyntheticSections(nightlyData)
+                return [{
+                    version: 'nightly',
+                    date: new Date().toLocaleDateString('en-CA'),
+                    heading: `What's new in nightly (synthetic):`,
+                    entries: [{ raw: '*) nightly - Nightly build from mt.lv/nightly-build (see nightly.json)', important: false, secure: false, subsystem: 'nightly', text: 'Nightly build from mt.lv/nightly-build — see docs/nightly/nightly.json' }],
+                    sourceUrl: 'https://mt.lv/nightly-build',
+                }]
+            }
             if (_changelogCache[version]) return _changelogCache[version]
 
             const request = fetch(`https://download.mikrotik.com/routeros/${version}/CHANGELOG`)
@@ -701,7 +739,11 @@
                     if (!response.ok) throw new Error(`HTTP ${response.status}`)
                     return response.text()
                 })
-                .then(text => parseChangelogSections(text))
+                .then(text => {
+                    const secs = parseChangelogSections(text)
+                    for (const s of secs) s.sourceUrl = `https://download.mikrotik.com/routeros/${version}/CHANGELOG`
+                    return secs
+                })
 
             _changelogCache[version] = request
             try {
@@ -730,6 +772,14 @@
 
             try {
                 const versions = getChangelogVersionsInRange(range)
+                // Synthetic nightly section when the range touches the nightly slot
+                let nightlySections = []
+                if (isNightly(range.newer) || isNightly(range.older)) {
+                    try {
+                        const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
+                        if (nightlyData) nightlySections = createNightlySyntheticSections(nightlyData)
+                    } catch (e) { console.warn('Failed to load nightly synthetic changelog', e) }
+                }
                 const sectionGroups = await Promise.all(
                     versions.map(async version => {
                         const sections = await fetchChangelogSectionsForVersion(version)
@@ -745,8 +795,8 @@
                     })
                 )
 
-                const flattenedSections = sectionGroups.flat()
-                if (!flattenedSections.length && versions.length === 0) {
+                const flattenedSections = [...nightlySections, ...sectionGroups.flat()]
+                if (!flattenedSections.length && versions.length === 0 && nightlySections.length === 0) {
                     throw new Error(`No built RouterOS versions found between ${range.older} and ${range.newer}`)
                 }
 
@@ -758,7 +808,8 @@
                 changelogRangeStatus.hidden = true
                 changelogRangeContent.hidden = false
                 changelogRangeCount.textContent = ''
-                const fallbackUrl = escapeHtml(`https://download.mikrotik.com/routeros/${range.newer}/CHANGELOG`)
+                const fallbackHref = isNightly(range.newer) ? 'https://mt.lv/nightly-build' : `https://download.mikrotik.com/routeros/${range.newer}/CHANGELOG`
+                const fallbackUrl = escapeHtml(fallbackHref)
                 changelogRangeContent.innerHTML = `
                     <p style="text-align:center; padding:2rem 1rem">
                         <span style="font-size:2rem">📋</span><br><br>
@@ -787,6 +838,7 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             const diffShowAll = document.getElementById('diffShowAll')
+            const diffShowNightly = document.getElementById('diffShowNightly')
 
             // Process queued builddir events that fired before DOMContentLoaded
             if (_pendingBuildDirs.length) {
@@ -798,11 +850,22 @@
             }
             document.removeEventListener('builddir', _earlyBuilddirListener)
 
-            diffShowAll.addEventListener('change', () => {
-                _diffShowAll = diffShowAll.checked
-                rebuildSelect(compare1, _diffVersions, _diffShowAll)
-                rebuildSelect(compare2, _diffVersions, _diffShowAll)
-            })
+            if (diffShowAll) {
+                diffShowAll.addEventListener('change', () => {
+                    _diffShowAll = diffShowAll.checked
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    writeQueryParams()
+                })
+            }
+            if (diffShowNightly) {
+                diffShowNightly.addEventListener('change', () => {
+                    _diffShowNightly = diffShowNightly.checked
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    writeQueryParams()
+                })
+            }
         })
 
         // Populate diff dropdowns from builddir events
@@ -812,8 +875,8 @@
                 _diffVersions.push(file.name)
                 _diffVersions.sort(compareVersions)
             }
-            rebuildSelect(compare1, _diffVersions, _diffShowAll)
-            rebuildSelect(compare2, _diffVersions, _diffShowAll)
+            rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+            rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
         })
 
         // -----------------------------------------------------------------
@@ -1078,14 +1141,31 @@
                 })
         }
 
-        // Fetch version list (cached in localStorage by shared JS)
-        fetchVersionList()
-            .then(data => {
+        // Fetch version list (cached in localStorage by shared JS) + nightly badge
+        Promise.all([fetchVersionList(), fetchNightlyJson().catch(() => null)])
+            .then(([data]) => {
                 data.forEach(f => document.dispatchEvent(new CustomEvent('builddir', { detail: f })))
+                // Refresh nightly labels once badge data is available
+                if (getCachedNightlyJson()) {
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                }
                 // Apply URL query params after all version options are populated
                 applyQueryParams()
+                // Re-apply after query may have enabled nightly
+                if (getCachedNightlyJson()) {
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                }
             })
             .catch(err => console.error('Error fetching version list:', err))
+
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchNightlyJson().then(() => {
+                rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+            }).catch(() => {})
+        })
 
         // -----------------------------------------------------------------
         // Query string: read initial params & write on change
@@ -1096,6 +1176,7 @@
             if (compare2.value) params.set('compare2', compare2.value)
             if (!diffextra.checked) params.set('extra', 'false')
             if (_diffShowAll) params.set('testing', 'true')
+            if (_diffShowNightly) params.set('nightly', 'true')
             const fmt = document.getElementById('diffFormat').value
             if (fmt !== 'side-by-side') params.set('format', fmt)
             const ctx = document.getElementById('diffContext').value
@@ -1116,6 +1197,7 @@
             const q2 = params.get('compare2')
             const extra = params.get('extra')
             const testing = params.get('testing')
+            const nightly = params.get('nightly')
             const fmt = params.get('format')
             const ctx = params.get('context')
             const hunks = params.get('hunks')
@@ -1123,12 +1205,28 @@
             const changelogFilter = params.get('changelogFilter')
             const changelogSort = params.get('changelogSort')
             const diffShowAll = document.getElementById('diffShowAll')
+            const diffShowNightly = document.getElementById('diffShowNightly')
 
+            let needsRebuild = false
             if (testing === 'true' && !_diffShowAll) {
                 _diffShowAll = true
-                diffShowAll.checked = true
-                rebuildSelect(compare1, _diffVersions, true)
-                rebuildSelect(compare2, _diffVersions, true)
+                if (diffShowAll) diffShowAll.checked = true
+                needsRebuild = true
+            }
+            if (nightly === 'true' && !_diffShowNightly) {
+                _diffShowNightly = true
+                if (diffShowNightly) diffShowNightly.checked = true
+                needsRebuild = true
+            }
+            // Auto-enable nightly if query asks for it explicitly
+            if ([q1, q2].some(v => v === 'nightly') && !_diffShowNightly) {
+                _diffShowNightly = true
+                if (diffShowNightly) diffShowNightly.checked = true
+                needsRebuild = true
+            }
+            if (needsRebuild) {
+                rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
             }
             if (extra === 'false') diffextra.checked = false
 

--- a/docs/diff.html
+++ b/docs/diff.html
@@ -636,7 +636,7 @@
 
         function getChangelogVersionsInRange(range) {
             // Use shared helper which always excludes synthetic nightly (no CHANGELOG on download.mikrotik.com)
-            if (typeof window.getChangelogVersionsInRange === 'function' && window.getChangelogVersionsInRange.length === 3) {
+            if (typeof window.getChangelogVersionsInRange === 'function') {
                 // Shared helper is available (N5) — it already excludes nightly
                 return window.getChangelogVersionsInRange(range, _diffVersions, _diffShowAll)
             }
@@ -722,7 +722,8 @@
                 if (typeof window.fetchChangelogSectionsForVersion === 'function') {
                     return window.fetchChangelogSectionsForVersion(version)
                 }
-                const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
+                const cached = getCachedNightlyJson()
+                const nightlyData = (cached && !cached._partial) ? cached : await fetchNightlyJson()
                 if (nightlyData) return createNightlySyntheticSections(nightlyData)
                 return [{
                     version: 'nightly',
@@ -776,7 +777,8 @@
                 let nightlySections = []
                 if (isNightly(range.newer) || isNightly(range.older)) {
                     try {
-                        const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
+                        const cached = getCachedNightlyJson()
+                        const nightlyData = (cached && !cached._partial) ? cached : await fetchNightlyJson()
                         if (nightlyData) nightlySections = createNightlySyntheticSections(nightlyData)
                     } catch (e) { console.warn('Failed to load nightly synthetic changelog', e) }
                 }
@@ -796,7 +798,7 @@
                 )
 
                 const flattenedSections = [...nightlySections, ...sectionGroups.flat()]
-                if (!flattenedSections.length && versions.length === 0 && nightlySections.length === 0) {
+                if (!flattenedSections.length && versions.length === 0) {
                     throw new Error(`No built RouterOS versions found between ${range.older} and ${range.newer}`)
                 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,6 +146,10 @@
                         <input id="diffShowAll" type="checkbox" role="switch">
                         include <code>testing</code>
                     </label>
+                    <label class="ml-1">
+                        <input id="diffShowNightly" type="checkbox" role="switch">
+                        include <code>nightly</code>
+                    </label>
                 </ul>
             </nav>
 
@@ -213,6 +217,10 @@
                         <input id="schemaShowAll" type="checkbox" role="switch">
                         include <code>testing</code>
                     </label>
+                    <label class="ml-1">
+                        <input id="schemaShowNightly" type="checkbox" role="switch">
+                        include <code>nightly</code>
+                    </label>
                 </ul>
             </nav>
             <article>
@@ -221,7 +229,8 @@
                     <code>extra-packages.zip</code> available for X86.</i><br>
                 <small>📬 The <strong>RAML</strong> schema can be imported into <a href="https://www.postman.com/" target="_blank" rel="noopener">Postman</a> — see <a href="https://github.com/tikoci/restraml/blob/main/README.md#usage-with-postman">README.md</a> for import instructions.</small><br>
                 <small>🔍 <strong>OpenAPI 3</strong> schemas power the <a href="openapi.html">API Explorer</a> — an interactive browser for the RouterOS REST API with enriched descriptions.</small><br>
-                <small>📋 <strong><code>/app</code> YAML</strong> columns (7.22+) provide per-version JSON Schema files for validating RouterOS <code>/app</code> container YAML — <i>/app</i> for single-app definitions, <i>store</i> for <code>app-store-urls=</code> arrays. See the callout below for version-independent <i>latest</i> links.</small>
+                <small>📋 <strong><code>/app</code> YAML</strong> columns (7.22+) provide per-version JSON Schema files for validating RouterOS <code>/app</code> container YAML — <i>/app</i> for single-app definitions, <i>store</i> for <code>app-store-urls=</code> arrays. See the callout below for version-independent <i>latest</i> links.</small><br>
+                <small>🌙 <strong><code>nightly</code></strong> is the Box share at <a href="https://mt.lv/nightly-build">mt.lv/nightly-build</a> — single overwritten slot <code>docs/nightly/</code> with badge <code>nightly (7.25_ab434)</code> &middot; age. Its <code>extra/</code> is partial (no <code>dude</code>/<code>user-manager</code>/etc.), see <code>nightly.json</code> for packages and build window.</small>
             </article>
             <table>
                 <thead>
@@ -350,6 +359,33 @@
         // Changelog / Release Notes modal
         // -----------------------------------------------------------------
         const filerows = document.getElementById('filerows')
+        let _schemaShowAll = false
+        let _schemaShowNightly = false
+
+        // Helper to refresh nightly badge labels after nightly.json loads
+        function refreshNightlyLabels() {
+            document.querySelectorAll('.row-ver[data-version="nightly"] .cell-vername a').forEach(a => {
+                a.textContent = formatVersionLabelWithAge('nightly')
+                a.href = getChangelogUrl('nightly')
+                const cached = getCachedNightlyJson()
+                if (cached?.nightlyVersion) {
+                    const age = formatRelativeAge(cached.builtAt)
+                    if (age) a.title = `Nightly ${cached.nightlyVersion} · built ${age}`
+                }
+            })
+            // Update selects if they contain nightly
+            if (typeof _diffVersions !== 'undefined' && _diffVersions.includes('nightly')) {
+                const c1 = document.getElementById('compare1')
+                const c2 = document.getElementById('compare2')
+                if (c1 && c2) {
+                    const v1 = c1.value, v2 = c2.value
+                    rebuildSelect(c1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(c2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    if (v1) c1.value = v1
+                    if (v2) c2.value = v2
+                }
+            }
+        }
 
         // initChangelogModal wires up all modal event handlers and returns showChangelog.
         // getVersions() returns _diffVersions (which includes/excludes testing per _diffShowAll).
@@ -377,10 +413,16 @@
 
             // Version label — keeps CHANGELOG URL as fallback href (right-click → open in tab),
             // but JS intercepts left-click to show the inline modal instead.
+            // For nightly show `nightly (7.25_ab434)` with age; nightly.json badge.
             const cellver = verrow.querySelector('.cell-vername a')
-            cellver.href = `https://download.mikrotik.com/routeros/${file.name}/CHANGELOG`
-            cellver.textContent = file.name
+            const isNightlyRow = isNightly(file.name)
+            cellver.href = getChangelogUrl(file.name)
+            cellver.textContent = isNightlyRow ? formatVersionLabelWithAge(file.name) : file.name
             cellver.dataset.changelogVersion = file.name
+            if (isNightlyRow && getCachedNightlyJson()?.nightlyVersion) {
+                const age = formatRelativeAge(getCachedNightlyJson().builtAt)
+                if (age) cellver.title = `Nightly ${getCachedNightlyJson().nightlyVersion} · built ${age}`
+            }
 
             // Helper: populate a cell with base/extra download links
             function makeVerCellExtra(schematype, schemafile, opts = { base: true }) {
@@ -397,8 +439,9 @@
             }
 
             makeVerCellExtra('raml', 'schema.raml')
-            // OpenAPI with docs shipped from 7.22.1+; older versions only have oas2.json
-            const hasOpenApi = compareVersions(file.name, '7.22.1') <= 0
+            // OpenAPI with docs shipped from 7.22.1+; older versions only have oas2.json.
+            // Nightly always has OpenAPI.
+            const hasOpenApi = isNightly(file.name) || compareVersions(file.name, '7.22.1') <= 0
             if (hasOpenApi) {
                 makeVerCellExtra('openapi', 'openapi.json')
             }
@@ -419,8 +462,8 @@
                 openapiCell.appendChild(exploreLink)
             }
 
-            // /app YAML schema links (7.22+)
-            const hasAppYaml = compareVersions(file.name, '7.22') <= 0
+            // /app YAML schema links (7.22+). Suppressed for nightly — only app.json is published there (N6).
+            const hasAppYaml = !isNightly(file.name) && compareVersions(file.name, '7.22') <= 0
             const appYamlCell = verrow.querySelector('.cell-appyaml')
             if (hasAppYaml) {
                 const wrap = document.createElement('small')
@@ -441,37 +484,64 @@
                 wrap.appendChild(label)
                 wrap.appendChild(links)
                 appYamlCell.appendChild(wrap)
+            } else if (isNightlyRow) {
+                appYamlCell.innerHTML = '<small style="opacity:0.6">n/a<br><span style="font-size:0.8em">see nightly/app.json</span></small>'
             }
 
-            // SNMP MIB link
-            verrow.querySelector('.cell-mib a').href =
-                `https://download.mikrotik.com/routeros/${file.name}/mikrotik.mib`
+            // SNMP MIB link — nightly has no MIB on download.mikrotik.com
+            const mibCell = verrow.querySelector('.cell-mib')
+            const mibUrl = getMibUrl(file.name)
+            if (mibUrl) {
+                mibCell.querySelector('a').href = mibUrl
+            } else {
+                mibCell.innerHTML = '<small style="opacity:0.6"><mark>SNMP</mark> n/a<br><span style="font-size:0.8em">Box share</span></small>'
+            }
 
             // Tag row with version name for filtering
             const tr = verrow.querySelector('.row-ver')
             tr.dataset.version = file.name
 
-            // Hide pre-release rows by default
-            if (isPreRelease(file.name)) {
-                tr.style.display = 'none'
+            // Hide pre-release rows by default (testing and nightly separately)
+            if (isNightly(file.name)) {
+                if (!_schemaShowNightly) tr.style.display = 'none'
+            } else if (isTestingPreRelease(file.name)) {
+                if (!_schemaShowAll) tr.style.display = 'none'
             }
 
             filerows.appendChild(verrow)
         })
 
         // -----------------------------------------------------------------
-        // "include testing" toggle for schema downloads table
+        // "include testing/nightly" toggles for schema downloads table
         // -----------------------------------------------------------------
         document.addEventListener('DOMContentLoaded', () => {
             const schemaShowAll = document.getElementById('schemaShowAll')
-            schemaShowAll.addEventListener('change', () => {
-                const show = schemaShowAll.checked
-                document.querySelectorAll('#filerows .row-ver').forEach(row => {
-                    if (isPreRelease(row.dataset.version)) {
-                        row.style.display = show ? '' : 'none'
-                    }
+            const schemaShowNightly = document.getElementById('schemaShowNightly')
+            if (schemaShowAll) {
+                schemaShowAll.addEventListener('change', () => {
+                    _schemaShowAll = schemaShowAll.checked
+                    document.querySelectorAll('#filerows .row-ver').forEach(row => {
+                        if (isTestingPreRelease(row.dataset.version)) {
+                            row.style.display = _schemaShowAll ? '' : 'none'
+                        }
+                    })
+                    writeQueryParams()
                 })
-            })
+            }
+            if (schemaShowNightly) {
+                schemaShowNightly.addEventListener('change', () => {
+                    _schemaShowNightly = schemaShowNightly.checked
+                    document.querySelectorAll('#filerows .row-ver').forEach(row => {
+                        if (isNightly(row.dataset.version)) {
+                            row.style.display = _schemaShowNightly ? '' : 'none'
+                        }
+                    })
+                    // Also refresh diff dropdowns so nightly appears there
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    writeQueryParams()
+                })
+            }
         })
 
         // -----------------------------------------------------------------
@@ -499,11 +569,13 @@
         // All collected versions for diff dropdowns (sorted at insertion time)
         const _diffVersions = []
         let _diffShowAll = false
+        let _diffShowNightly = false
 
-        // "include testing" toggle for diff dropdowns
+        // "include testing/nightly" toggles for diff dropdowns
         // Uses rebuildSelect() instead of option.hidden for Safari compatibility.
         document.addEventListener('DOMContentLoaded', () => {
             const diffShowAll = document.getElementById('diffShowAll')
+            const diffShowNightly = document.getElementById('diffShowNightly')
 
             // Process any queued builddir events that fired before DOMContentLoaded
             if (_pendingBuildDirs.length) {
@@ -519,11 +591,31 @@
             // Remove the early listener now that we've processed queued events
             document.removeEventListener('builddir', _earlyBuilddirListener)
 
-            diffShowAll.addEventListener('change', () => {
-                _diffShowAll = diffShowAll.checked
-                rebuildSelect(compare1, _diffVersions, _diffShowAll)
-                rebuildSelect(compare2, _diffVersions, _diffShowAll)
-            })
+            if (diffShowAll) {
+                diffShowAll.addEventListener('change', () => {
+                    _diffShowAll = diffShowAll.checked
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    writeQueryParams()
+                })
+            }
+            if (diffShowNightly) {
+                diffShowNightly.addEventListener('change', () => {
+                    _diffShowNightly = diffShowNightly.checked
+                    // Sync schema nightly toggle for consistent table visibility
+                    const schemaNightly = document.getElementById('schemaShowNightly')
+                    if (schemaNightly) {
+                        schemaNightly.checked = _diffShowNightly
+                        _schemaShowNightly = _diffShowNightly
+                        document.querySelectorAll('#filerows .row-ver').forEach(row => {
+                            if (isNightly(row.dataset.version)) row.style.display = _diffShowNightly ? '' : 'none'
+                        })
+                    }
+                    rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                    writeQueryParams()
+                })
+            }
         })
 
         // Populate diff dropdowns from builddir events
@@ -534,8 +626,8 @@
                 _diffVersions.sort(compareVersions)
             }
             // Rebuild both selects with current filter state
-            rebuildSelect(compare1, _diffVersions, _diffShowAll)
-            rebuildSelect(compare2, _diffVersions, _diffShowAll)
+            rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+            rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
         })
 
         // Update "Show/Hide JSON Diff" toggle label based on open state
@@ -553,6 +645,7 @@
             if (compare2.value) params.set('compare2', compare2.value)
             if (!diffextra.checked) params.set('extra', 'false')
             if (_diffShowAll) params.set('testing', 'true')
+            if (_diffShowNightly) params.set('nightly', 'true')
             const qs = params.toString()
             history.replaceState(null, '', qs ? '?' + qs : window.location.pathname)
         }
@@ -563,18 +656,34 @@
             const q2 = params.get('compare2')
             const extra = params.get('extra')
             const testing = params.get('testing')
+            const nightly = params.get('nightly')
             const diffShowAll = document.getElementById('diffShowAll')
+            const diffShowNightly = document.getElementById('diffShowNightly')
             const schemaShowAll = document.getElementById('schemaShowAll')
+            const schemaShowNightly = document.getElementById('schemaShowNightly')
 
-            // Apply "testing" flag first so pre-release versions are available
+            // Apply "testing" and "nightly" flags first so those versions are available
+            let needsRebuild = false
             if (testing === 'true' && !_diffShowAll) {
                 _diffShowAll = true
-                diffShowAll.checked = true
-                schemaShowAll.checked = true
-                rebuildSelect(compare1, _diffVersions, true)
-                rebuildSelect(compare2, _diffVersions, true)
+                if (diffShowAll) diffShowAll.checked = true
+                if (schemaShowAll) { schemaShowAll.checked = true; _schemaShowAll = true }
+                needsRebuild = true
+            }
+            if (nightly === 'true' && !_diffShowNightly) {
+                _diffShowNightly = true
+                _schemaShowNightly = true
+                if (diffShowNightly) diffShowNightly.checked = true
+                if (schemaShowNightly) schemaShowNightly.checked = true
+                needsRebuild = true
+            }
+            // Legacy: ?testing=true without nightly implied nightly previously — keep nightly hidden unless explicitly requested
+            if (needsRebuild) {
+                rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
                 document.querySelectorAll('#filerows .row-ver').forEach(row => {
-                    if (isPreRelease(row.dataset.version)) row.style.display = ''
+                    if (isTestingPreRelease(row.dataset.version) && _diffShowAll) row.style.display = ''
+                    if (isNightly(row.dataset.version) && _diffShowNightly) row.style.display = ''
                 })
             }
 
@@ -588,6 +697,21 @@
             if (q2 && [...compare2.options].some(o => o.value === q2)) {
                 compare2.value = q2
                 needsCompare = true
+            }
+            // If compare params include nightly but toggle wasn't set via query, auto-enable nightly
+            const needsNightly = [q1, q2].some(v => v === 'nightly')
+            if (needsNightly && !_diffShowNightly) {
+                _diffShowNightly = true
+                _schemaShowNightly = true
+                if (diffShowNightly) diffShowNightly.checked = true
+                if (schemaShowNightly) schemaShowNightly.checked = true
+                rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
+                document.querySelectorAll('#filerows .row-ver').forEach(row => {
+                    if (isNightly(row.dataset.version)) row.style.display = ''
+                })
+                if (q1 && [...compare1.options].some(o => o.value === q1)) compare1.value = q1
+                if (q2 && [...compare2.options].some(o => o.value === q2)) compare2.value = q2
             }
             if (needsCompare && compare1.value && compare2.value) {
                 document.dispatchEvent(new Event('vercompare'))
@@ -648,6 +772,7 @@
                     if (compare2.value) dparams.set('compare2', compare2.value)
                     if (!diffextra.checked) dparams.set('extra', 'false')
                     if (_diffShowAll) dparams.set('testing', 'true')
+                    if (_diffShowNightly) dparams.set('nightly', 'true')
                     diffToolLink.href = 'diff.html?' + dparams.toString()
                     diffToolLinkP.hidden = false
                 }
@@ -691,16 +816,25 @@
         // -----------------------------------------------------------------
         // Main: fetch version list (cached in localStorage by shared JS)
         // -----------------------------------------------------------------
-        fetchVersionList()
-            .then(versionDirs => {
+        Promise.all([fetchVersionList(), fetchNightlyJson().catch(() => null)])
+            .then(([versionDirs]) => {
                 versionDirs.forEach(file => {
                     file.pagesUrl = `${pagesUrl}/${file.path.replace('docs/', '')}`
                     document.dispatchEvent(new CustomEvent('builddir', { detail: file }))
                 })
+                // Refresh nightly badges now that nightly.json is cached (if published)
+                refreshNightlyLabels()
                 // Apply URL query params after all version options are populated
                 applyQueryParams()
+                // Second refresh after query params may have enabled nightly
+                refreshNightlyLabels()
             })
             .catch(error => console.error('Error fetching build list from GitHub:', error))
+
+        // Re-attempt nightly refresh once DOM is ready (covers early builddir queue)
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchNightlyJson().then(() => refreshNightlyLabels()).catch(() => {})
+        })
 
         // --- WebMCP: get_routeros_changelog tool ---
         const _wmcp = registerWebMCPTools()
@@ -723,7 +857,31 @@
                 required: ['version'],
             },
             execute: async ({ version, query }) => {
-                const url = `https://download.mikrotik.com/routeros/${version}/CHANGELOG`
+                // Nightly: synthetic section from nightly.json
+                if (isNightly(version)) {
+                    try {
+                        const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
+                        if (nightlyData) {
+                            const sections = createNightlySyntheticSections(nightlyData)
+                            const q = query ? query.toLowerCase() : ''
+                            const allEntries = sections.flatMap(s => s.entries)
+                            const filtered = q ? allEntries.filter(e => e.raw.toLowerCase().includes(q) || e.subsystem.toLowerCase().includes(q) || e.text.toLowerCase().includes(q)) : allEntries
+                            return JSON.stringify({
+                                version,
+                                releaseDate: nightlyData.builtAt,
+                                nightlyVersion: nightlyData.nightlyVersion,
+                                entries: filtered.map(e => ({ subsystem: e.subsystem, text: e.text, important: e.important })),
+                                totalEntries: allEntries.length,
+                                matchedEntries: filtered.length,
+                                source: 'https://mt.lv/nightly-build',
+                            })
+                        }
+                        return JSON.stringify({ error: 'Nightly not yet published', fallbackUrl: 'https://mt.lv/nightly-build' })
+                    } catch (e) {
+                        return JSON.stringify({ error: e.message, fallbackUrl: 'https://mt.lv/nightly-build' })
+                    }
+                }
+                const url = getChangelogUrl(version)
                 try {
                     const resp = await fetch(url)
                     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)

--- a/docs/index.html
+++ b/docs/index.html
@@ -536,7 +536,10 @@
                             row.style.display = _schemaShowNightly ? '' : 'none'
                         }
                     })
-                    // Also refresh diff dropdowns so nightly appears there
+                    // Sync the diff nightly toggle so nightly appears in the dropdowns
+                    _diffShowNightly = _schemaShowNightly
+                    const diffNightly = document.getElementById('diffShowNightly')
+                    if (diffNightly) diffNightly.checked = _diffShowNightly
                     rebuildSelect(compare1, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
                     rebuildSelect(compare2, _diffVersions, { includeTesting: _diffShowAll, includeNightly: _diffShowNightly })
                     writeQueryParams()
@@ -645,7 +648,7 @@
             if (compare2.value) params.set('compare2', compare2.value)
             if (!diffextra.checked) params.set('extra', 'false')
             if (_diffShowAll) params.set('testing', 'true')
-            if (_diffShowNightly) params.set('nightly', 'true')
+            if (_diffShowNightly || _schemaShowNightly) params.set('nightly', 'true')
             const qs = params.toString()
             history.replaceState(null, '', qs ? '?' + qs : window.location.pathname)
         }
@@ -857,26 +860,23 @@
                 required: ['version'],
             },
             execute: async ({ version, query }) => {
-                // Nightly: synthetic section from nightly.json
+                // Nightly: synthetic section from nightly.json via shared helper
                 if (isNightly(version)) {
                     try {
-                        const nightlyData = getCachedNightlyJson() || await fetchNightlyJson()
-                        if (nightlyData) {
-                            const sections = createNightlySyntheticSections(nightlyData)
-                            const q = query ? query.toLowerCase() : ''
-                            const allEntries = sections.flatMap(s => s.entries)
-                            const filtered = q ? allEntries.filter(e => e.raw.toLowerCase().includes(q) || e.subsystem.toLowerCase().includes(q) || e.text.toLowerCase().includes(q)) : allEntries
-                            return JSON.stringify({
-                                version,
-                                releaseDate: nightlyData.builtAt,
-                                nightlyVersion: nightlyData.nightlyVersion,
-                                entries: filtered.map(e => ({ subsystem: e.subsystem, text: e.text, important: e.important })),
-                                totalEntries: allEntries.length,
-                                matchedEntries: filtered.length,
-                                source: 'https://mt.lv/nightly-build',
-                            })
-                        }
-                        return JSON.stringify({ error: 'Nightly not yet published', fallbackUrl: 'https://mt.lv/nightly-build' })
+                        const sections = await fetchChangelogSectionsForVersion(version)
+                        const nightlyData = getCachedNightlyJson()
+                        const q = query ? query.toLowerCase() : ''
+                        const allEntries = sections.flatMap(s => s.entries)
+                        const filtered = q ? allEntries.filter(e => e.raw.toLowerCase().includes(q) || e.subsystem.toLowerCase().includes(q) || e.text.toLowerCase().includes(q)) : allEntries
+                        return JSON.stringify({
+                            version,
+                            releaseDate: nightlyData?.builtAt || null,
+                            nightlyVersion: nightlyData?.nightlyVersion || null,
+                            entries: filtered.map(e => ({ subsystem: e.subsystem, text: e.text, important: e.important })),
+                            totalEntries: allEntries.length,
+                            matchedEntries: filtered.length,
+                            source: 'https://mt.lv/nightly-build',
+                        })
                     } catch (e) {
                         return JSON.stringify({ error: e.message, fallbackUrl: 'https://mt.lv/nightly-build' })
                     }

--- a/docs/lookup.html
+++ b/docs/lookup.html
@@ -262,8 +262,8 @@
                     <mark>include testing</mark> adds beta and RC builds to the version list
                     and automatically enables all-version scanning.
                     <mark>include nightly</mark> shows the single overwritten slot
-                    <code>nightly (7.25_ab434)</code> from
-                    <a href="https://mt.lv/nightly-build">mt.lv/nightly-build</a> — badge includes age; its
+                    <code>nightly</code> from
+                    <a href="https://mt.lv/nightly-build">mt.lv/nightly-build</a> — badge includes version and age; its
                     <code>extra/</code> is partial (no <code>dude</code>/<code>user-manager</code>/etc., see <code>nightly.json</code>).
                 </p>
             </article>
@@ -404,7 +404,7 @@
             allVersions.forEach(name => {
                 const show = shouldShowVersion(name, showTesting, showNightly)
                 if (show) {
-                    const label = formatVersionLabel(name)
+                    const label = formatVersionLabelWithAge(name)
                     versionSelect.appendChild(new Option(label, name))
                 }
             })
@@ -437,7 +437,10 @@
             if (files.some(file => file.name === 'deep-inspect.json')) {
                 return 'deep-inspect.json'
             }
-            // Nightly extra stores per-arch deep-inspect files (deep-inspect.x86.json etc.)
+            // Nightly extra stores per-arch deep-inspect files; prefer x86 (canonical) when both exist,
+            // otherwise fall back to any variant (e.g. arm64). Do not rely on manifest order.
+            const x86Variant = files.find(file => file.name === 'deep-inspect.x86.json')
+            if (x86Variant) return x86Variant.name
             const deepInspectVariant = files.find(file => file.name.startsWith('deep-inspect.') && file.name.endsWith('.json'))
             if (deepInspectVariant) return deepInspectVariant.name
             return 'inspect.json'
@@ -641,7 +644,7 @@
             const tdVer = document.createElement('td')
             const link = document.createElement('a')
             link.href = getChangelogUrl(ver)
-            link.textContent = formatVersionLabel(ver)
+            link.textContent = formatVersionLabelWithAge(ver)
             link.dataset.changelogVersion = ver
             if (result.sourceFile) {
                 link.title = `Lookup used ${result.sourceFile}`
@@ -776,7 +779,7 @@
                 // Single version
                 const ver = versionsToCheck[0]
                 const verb = foundCount > 0 ? 'Found' : 'Not found'
-                const verLabel = formatVersionLabel(ver)
+                const verLabel = formatVersionLabelWithAge(ver)
                 summary = `<p>${verb} in <strong>${verLabel}</strong> (${schemaLabel} schema) &mdash; ` +
                     `<code>${normalizedPath}</code>${attrPart}</p>`
             } else {

--- a/docs/lookup.html
+++ b/docs/lookup.html
@@ -183,6 +183,12 @@
                             include <code>testing</code>
                         </label>
                     </li>
+                    <li>
+                        <label>
+                            <input id="includeNightly" type="checkbox" role="switch">
+                            include <code>nightly</code>
+                        </label>
+                    </li>
                 </ul>
             </nav>
         </section>
@@ -255,6 +261,10 @@
                     <mark>check all versions</mark> scans every published release at once.
                     <mark>include testing</mark> adds beta and RC builds to the version list
                     and automatically enables all-version scanning.
+                    <mark>include nightly</mark> shows the single overwritten slot
+                    <code>nightly (7.25_ab434)</code> from
+                    <a href="https://mt.lv/nightly-build">mt.lv/nightly-build</a> — badge includes age; its
+                    <code>extra/</code> is partial (no <code>dude</code>/<code>user-manager</code>/etc., see <code>nightly.json</code>).
                 </p>
             </article>
 
@@ -359,6 +369,7 @@
         const versionSelect = document.getElementById('version-select')
         const checkAllVersions = document.getElementById('checkAllVersions')
         const includeTesting = document.getElementById('includeTesting')
+        const includeNightly = document.getElementById('includeNightly')
         const includeExtra = document.getElementById('includeExtra')
         const resultsSection = document.getElementById('results-section')
         const resultsSummary = document.getElementById('results-summary')
@@ -388,10 +399,13 @@
         function rebuildVersionSelect() {
             const current = versionSelect.value
             while (versionSelect.options.length > 0) versionSelect.remove(0)
-            const showAll = includeTesting.checked
+            const showTesting = includeTesting.checked
+            const showNightly = includeNightly.checked
             allVersions.forEach(name => {
-                if (showAll || !isPreRelease(name)) {
-                    versionSelect.appendChild(new Option(name, name))
+                const show = shouldShowVersion(name, showTesting, showNightly)
+                if (show) {
+                    const label = formatVersionLabel(name)
+                    versionSelect.appendChild(new Option(label, name))
                 }
             })
             // Restore prior selection or default to newest
@@ -423,6 +437,9 @@
             if (files.some(file => file.name === 'deep-inspect.json')) {
                 return 'deep-inspect.json'
             }
+            // Nightly extra stores per-arch deep-inspect files (deep-inspect.x86.json etc.)
+            const deepInspectVariant = files.find(file => file.name.startsWith('deep-inspect.') && file.name.endsWith('.json'))
+            if (deepInspectVariant) return deepInspectVariant.name
             return 'inspect.json'
         }
 
@@ -623,11 +640,15 @@
             // right-click / middle-click falls back to the CHANGELOG URL.
             const tdVer = document.createElement('td')
             const link = document.createElement('a')
-            link.href = `https://download.mikrotik.com/routeros/${ver}/CHANGELOG`
-            link.textContent = ver
+            link.href = getChangelogUrl(ver)
+            link.textContent = formatVersionLabel(ver)
             link.dataset.changelogVersion = ver
             if (result.sourceFile) {
                 link.title = `Lookup used ${result.sourceFile}`
+            }
+            if (isNightly(ver) && getCachedNightlyJson()?.nightlyVersion) {
+                const age = formatRelativeAge(getCachedNightlyJson().builtAt)
+                if (age) link.title = (link.title ? link.title + ' — ' : '') + `nightly ${getCachedNightlyJson().nightlyVersion} · ${age}`
             }
             tdVer.appendChild(link)
             tr.appendChild(tdVer)
@@ -676,11 +697,12 @@
 
             const lookAll = checkAllVersions.checked
             const showTesting = includeTesting.checked
+            const showNightly = includeNightly.checked
             const useExtra = includeExtra.checked
 
             // Determine which versions to check
             const versionsToCheck = lookAll
-                ? allVersions.filter(v => showTesting || !isPreRelease(v))
+                ? allVersions.filter(v => shouldShowVersion(v, showTesting, showNightly))
                 : [versionSelect.value].filter(Boolean)
 
             if (versionsToCheck.length === 0) return
@@ -748,20 +770,22 @@
             // Build a smart summary sentence
             const schemaLabel = useExtra ? 'extra-packages' : 'base'
             const testingNote = showTesting ? ' (including testing)' : ''
+            const nightlyNote = showNightly ? ' + nightly' : ''
             let summary
             if (!lookAll) {
                 // Single version
                 const ver = versionsToCheck[0]
                 const verb = foundCount > 0 ? 'Found' : 'Not found'
-                summary = `<p>${verb} in <strong>${ver}</strong> (${schemaLabel} schema) &mdash; ` +
+                const verLabel = formatVersionLabel(ver)
+                summary = `<p>${verb} in <strong>${verLabel}</strong> (${schemaLabel} schema) &mdash; ` +
                     `<code>${normalizedPath}</code>${attrPart}</p>`
             } else {
                 // All versions
-                const allCount = allVersions.filter(v => showTesting || !isPreRelease(v)).length
+                const allCount = allVersions.filter(v => shouldShowVersion(v, showTesting, showNightly)).length
                 const scopeLabel = checkedCount === allCount
-                    ? `all ${checkedCount} ${showTesting ? 'stable and testing' : 'stable'} versions`
+                    ? `all ${checkedCount} ${showTesting ? 'stable and testing' : 'stable'}${showNightly ? ' + nightly' : ''} versions`
                     : `${checkedCount} version${checkedCount !== 1 ? 's' : ''}`
-                summary = `<p>Found in <strong>${foundCount}</strong> of ${scopeLabel}${testingNote} ` +
+                summary = `<p>Found in <strong>${foundCount}</strong> of ${scopeLabel}${testingNote}${nightlyNote} ` +
                     `(${schemaLabel} schema) &mdash; <code>${normalizedPath}</code>${attrPart}</p>`
             }
             if (attrStr && enrichedCount > 0) {
@@ -830,17 +854,33 @@
             }
             rebuildVersionSelect()
             triggerLookup(true)
+            writeQueryParams()
+        })
+
+        // "Include nightly" toggle → also implies all versions, rebuild, lookup
+        includeNightly.addEventListener('change', () => {
+            if (includeNightly.checked && !checkAllVersions.checked) {
+                checkAllVersions.checked = true
+                versionSelect.disabled = true
+            }
+            rebuildVersionSelect()
+            triggerLookup(true)
+            writeQueryParams()
         })
 
         // -----------------------------------------------------------------
         // Bootstrap: fetch version list (cached in localStorage by shared JS)
         // -----------------------------------------------------------------
-        fetchVersionList()
-            .then(data => {
+        Promise.all([fetchVersionList(), fetchNightlyJson().catch(() => null)])
+            .then(([data]) => {
                 setVersionEntries(data)
-                // Apply query params before rebuilding select (so testing flag is set)
+                // Refresh nightly badge once available
+                if (getCachedNightlyJson()) rebuildVersionSelect()
+                // Apply query params before rebuilding select (so testing/nightly flags are set)
                 const qVersion = applyQueryParams()
                 rebuildVersionSelect()
+                // Second refresh after query may have enabled nightly
+                if (getCachedNightlyJson()) rebuildVersionSelect()
                 // Apply specific version if requested (after options are built)
                 if (qVersion && [...versionSelect.options].some(o => o.value === qVersion)) {
                     versionSelect.value = qVersion
@@ -852,6 +892,10 @@
                 versionSelect.innerHTML = '<option value="" disabled selected>Failed to load versions</option>'
                 console.error('Error fetching version list:', err)
             })
+
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchNightlyJson().then(() => rebuildVersionSelect()).catch(() => {})
+        })
 
         // -----------------------------------------------------------------
         // Query string: read initial params & write on change
@@ -868,6 +912,7 @@
                 params.set('version', versionSelect.value)
             }
             if (includeTesting.checked) params.set('testing', 'true')
+            if (includeNightly.checked) params.set('nightly', 'true')
             if (includeExtra.checked) params.set('extra', 'true')
             const qs = params.toString()
             history.replaceState(null, '', qs ? '?' + qs : window.location.pathname)
@@ -881,6 +926,7 @@
             const version = params.get('version')
             const allVersionsParam = params.get('allVersions')
             const testing = params.get('testing')
+            const nightly = params.get('nightly')
             const extra = params.get('extra')
 
             if (path !== null) {
@@ -892,7 +938,18 @@
                 includeTesting.checked = true
                 checkAllVersions.checked = true
                 versionSelect.disabled = true
+            }
+            if (nightly === 'true') {
+                includeNightly.checked = true
+                checkAllVersions.checked = true
+                versionSelect.disabled = true
             } else if (allVersionsParam === 'true') {
+                checkAllVersions.checked = true
+                versionSelect.disabled = true
+            }
+            // Auto-enable nightly if version param is nightly
+            if (version === 'nightly' && !includeNightly.checked) {
+                includeNightly.checked = true
                 checkAllVersions.checked = true
                 versionSelect.disabled = true
             }

--- a/docs/openapi.html
+++ b/docs/openapi.html
@@ -433,6 +433,10 @@
                 <input id="includeTesting" type="checkbox">
                 <code>testing</code>
             </label>
+            <label class="toggle-label">
+                <input id="includeNightly" type="checkbox">
+                <code>nightly</code>
+            </label>
             <span id="actions-group">
                 <span id="cors-note">Test requests (<a id="toggle-test-request" href="#">hide</a>) requires CORS.</span>
                 <a id="openapi-download" href="#" download hidden>Download Schema</a>
@@ -488,6 +492,7 @@
         const versionSelect = document.getElementById('version-select');
         const extraCheck = document.getElementById('includeExtra');
         const testingCheck = document.getElementById('includeTesting');
+        const nightlyCheck = document.getElementById('includeNightly');
         const scalarStatus = document.getElementById('scalar-status');
         const toggleTestLink = document.getElementById('toggle-test-request');
         const downloadAnchor = document.getElementById('openapi-download');
@@ -534,12 +539,24 @@
                 for (const opt of versionSelect.options) {
                     if (opt.value === v) { versionSelect.value = v; break; }
                 }
+                // Auto-enable nightly if version is nightly
+                if (v === 'nightly' && nightlyCheck && !nightlyCheck.checked) {
+                    nightlyCheck.checked = true
+                    rebuildVersionSelect()
+                    for (const opt of versionSelect.options) {
+                        if (opt.value === v) { versionSelect.value = v; break; }
+                    }
+                }
             }
             if (params.has('extra')) {
                 extraCheck.checked = params.get('extra') !== 'false';
             }
             if (params.has('testing')) {
                 testingCheck.checked = params.get('testing') === 'true';
+                rebuildVersionSelect();
+            }
+            if (params.has('nightly')) {
+                nightlyCheck.checked = params.get('nightly') === 'true';
                 rebuildVersionSelect();
             }
         }
@@ -549,6 +566,7 @@
             if (versionSelect.value) params.set('version', versionSelect.value);
             if (!extraCheck.checked) params.set('extra', 'false');
             if (testingCheck.checked) params.set('testing', 'true');
+            if (nightlyCheck.checked) params.set('nightly', 'true');
             const qs = params.toString();
             const url = qs ? `${location.pathname}?${qs}` : location.pathname;
             history.replaceState(null, '', url);
@@ -572,7 +590,7 @@
             const filtered = allVersions
                 .filter(v => versionHasOpenApi(v, false) || versionHasOpenApi(v, true))
                 .map(v => v.name);
-            rebuildSelect(versionSelect, filtered, testingCheck.checked);
+            rebuildSelect(versionSelect, filtered, { includeTesting: testingCheck.checked, includeNightly: nightlyCheck.checked });
         }
 
         // --- Check if openapi.json exists for a version+subdir ---
@@ -691,6 +709,15 @@
             if (!versionSelect.value && versionSelect.options.length > 1) {
                 versionSelect.selectedIndex = 1;
             }
+            writeQueryParams();
+            loadScalar();
+        });
+        nightlyCheck.addEventListener('change', () => {
+            rebuildVersionSelect();
+            if (!versionSelect.value && versionSelect.options.length > 1) {
+                versionSelect.selectedIndex = 1;
+            }
+            writeQueryParams();
             loadScalar();
         });
 
@@ -710,10 +737,13 @@
             }
         });
 
-        fetchVersionList().then(versions => {
+        Promise.all([fetchVersionList(), fetchNightlyJson().catch(() => null)]).then(([versions]) => {
             allVersions = versions;
             rebuildVersionSelect();
             readQueryParams();
+            // Second rebuild after nightly badge may be available
+            rebuildVersionSelect();
+            if (nightlyCheck.checked) readQueryParams();
 
             // Auto-select: use query param, or default to first version with openapi
             if (!versionSelect.value && versionSelect.options.length > 1) {
@@ -728,6 +758,10 @@
         }).catch(err => {
             scalarStatus.innerHTML = `<p>Failed to load version list: ${err.message}</p>`;
         });
+
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchNightlyJson().then(() => rebuildVersionSelect()).catch(() => {})
+        })
 
         // --- WebMCP: get_openapi_schema_url tool ---
         const _wmcp = registerWebMCPTools();

--- a/docs/restraml-shared.js
+++ b/docs/restraml-shared.js
@@ -233,9 +233,10 @@ function getChangelogUrl(version) {
  */
 function fetchNightlyJson() {
     if (_nightlyJsonPromise) return _nightlyJsonPromise
-    _nightlyJsonPromise = _fetchNightlyJsonInner()
-    _nightlyJsonPromise.finally(() => { _nightlyJsonPromise = null })
-    return _nightlyJsonPromise
+    const p = _fetchNightlyJsonInner()
+    _nightlyJsonPromise = p
+    p.finally(() => { if (_nightlyJsonPromise === p) _nightlyJsonPromise = null }).catch(() => {})
+    return p
 }
 
 function _fetchNightlyJsonInner() {
@@ -356,8 +357,10 @@ function createNightlySyntheticSections(nightlyData) {
             text: `extra/ is partial — absent roots ${absent.join(', ')} have no nightly NPKs on Box, so diff vs release extra shows them as "removed"`,
         })
     }
+    const boxToken = nightlyData.source?.token
+    const boxUrl = boxToken ? ` → https://box.mikrotik.com/d/${boxToken}/` : ''
     entries.push({
-        raw: `*) source - Box share https://mt.lv/nightly-build → https://box.mikrotik.com/d/${nightlyData.source?.token || '5ce46054d5d2487e8755'}/`,
+        raw: `*) source - Box share https://mt.lv/nightly-build${boxUrl}`,
         important: false,
         secure: false,
         subsystem: 'source',
@@ -443,7 +446,7 @@ function renderChangelogSections(sections, query, contentEl, itemCountEl) {
  */
 async function fetchChangelogSectionsForVersion(version) {
     if (isNightly(version)) {
-        const nightlyData = _nightlyJsonData || await fetchNightlyJson()
+        const nightlyData = (_nightlyJsonData && !_nightlyJsonData._partial) ? _nightlyJsonData : await fetchNightlyJson()
         if (nightlyData) return createNightlySyntheticSections(nightlyData)
         // Fallback synthetic when nightly.json hasn't been fetched yet
         return [{
@@ -553,10 +556,12 @@ function _fetchVersionListInner() {
             if (data.nightly && typeof data.nightly.nightlyVersion === 'string') {
                 // Seed _nightlyJsonData with the minimal nightly fields so badge
                 // can render even before nightly.json is fetched.
+                // Marked _partial so consumers that need full provenance still fetch nightly.json.
                 if (!_nightlyJsonData) {
                     _nightlyJsonData = {
                         nightlyVersion: data.nightly.nightlyVersion,
                         builtAt: data.nightly.builtAt,
+                        _partial: true,
                     }
                 }
             }
@@ -859,7 +864,7 @@ function initChangelogModal(opts) {
     searchEl.addEventListener('input', () => {
         if (_rawText) renderChangelogContent(_rawText, _version, searchEl.value.trim(), contentEl, itemCountEl)
         // For nightly synthetic sections we re-render via sections
-        if (!_rawText && _version === 'nightly' && _nightlyJsonData) {
+        if (!_rawText && isNightly(_version) && _nightlyJsonData) {
             const sections = createNightlySyntheticSections(_nightlyJsonData)
             renderChangelogSections(sections, searchEl.value.trim(), contentEl, itemCountEl)
         }
@@ -908,7 +913,7 @@ function initChangelogModal(opts) {
         // Nightly: synthetic section from nightly.json (no 404)
         if (isNightlyVersion) {
             try {
-                const nightlyData = _nightlyJsonData || await fetchNightlyJson()
+                const nightlyData = (_nightlyJsonData && !_nightlyJsonData._partial) ? _nightlyJsonData : await fetchNightlyJson()
                 if (nightlyData) {
                     // Update title/subtitle with fresh nightly data
                     titleEl.textContent = `RouterOS nightly (${nightlyData.nightlyVersion}) — Release Notes`

--- a/docs/restraml-shared.js
+++ b/docs/restraml-shared.js
@@ -95,20 +95,398 @@ function isPreRelease(name) {
  * Rebuild a <select> element's options from a sorted version list.
  * Safari does not support `option.hidden`, so we add/remove options instead.
  * Preserves the current selection if still present.
+ *
+ * Supports both legacy `showAll` boolean (testing+nightly together) and
+ * the new `{includeTesting, includeNightly}` object for the N5 nightly
+ * toggle. When nightly info is cached via fetchNightlyJson(), the option
+ * label is shown as `nightly (7.25_ab434)` instead of bare `nightly`.
  */
 function rebuildSelect(sel, versions, showAll) {
     const selectedVal = sel.value
     // Remove all non-placeholder options
     while (sel.options.length > 1) sel.remove(1)
+    let includeTesting
+    let includeNightly
+    if (showAll !== null && typeof showAll === 'object') {
+        includeTesting = !!showAll.includeTesting
+        includeNightly = !!showAll.includeNightly
+    } else {
+        includeTesting = !!showAll
+        includeNightly = !!showAll
+    }
     versions.forEach(name => {
-        if (showAll || !isPreRelease(name)) {
-            sel.appendChild(new Option(name, name))
+        const isNightlyVersion = SYNTHETIC_VERSIONS.has(name)
+        const isTesting = /(?:beta|rc)\d*$/.test(name)
+        let show = true
+        if (isNightlyVersion) show = includeNightly
+        else if (isTesting) show = includeTesting
+        if (show) {
+            const label = isNightlyVersion && typeof formatVersionLabel === 'function'
+                ? formatVersionLabel(name)
+                : name
+            sel.appendChild(new Option(label, name))
         }
     })
     // Restore selection if the value is still in the list
     if ([...sel.options].some(o => o.value === selectedVal)) {
         sel.value = selectedVal
     }
+}
+
+// --- Nightly helpers (N5) ---------------------------------------------
+// Synthetic `nightly` slot: published at docs/nightly/ with provenance
+// docs/nightly/nightly.json. These helpers give every page a consistent
+// badge (`nightly (7.25_ab434) · 11h ago`), MIB/CHANGELOG fallbacks, and
+// the shared synthetic changelog section.
+
+const _NIGHTLY_JSON_CACHE_KEY = 'restraml_nightly_json_v1'
+const _NIGHTLY_JSON_TTL = 5 * 60 * 1000 // 5 minutes
+let _nightlyJsonData = null
+let _nightlyJsonPromise = null
+
+/**
+ * Returns true if the name is a synthetic nightly slot.
+ */
+function isNightly(name) {
+    return SYNTHETIC_VERSIONS.has(name)
+}
+
+/**
+ * Returns true if the name is a beta/rc pre-release (excludes nightly).
+ */
+function isTestingPreRelease(name) {
+    return /(?:beta|rc)\d*$/.test(name)
+}
+
+/**
+ * Whether a version should be shown given the two toggles.
+ */
+function shouldShowVersion(name, includeTesting, includeNightly) {
+    if (isNightly(name)) return !!includeNightly
+    if (isTestingPreRelease(name)) return !!includeTesting
+    return true
+}
+
+/**
+ * Format a relative age string from an ISO builtAt timestamp.
+ * e.g. "11h ago", "2d ago", "42m ago"
+ */
+function formatRelativeAge(builtAt) {
+    if (!builtAt) return ''
+    const ms = Date.now() - new Date(builtAt).getTime()
+    if (!Number.isFinite(ms) || ms < 0) return ''
+    const mins = Math.floor(ms / 60000)
+    if (mins < 1) return 'just now'
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    const days = Math.floor(hrs / 24)
+    if (days < 30) return `${days}d ago`
+    const months = Math.floor(days / 30)
+    return `${months}mo ago`
+}
+
+/**
+ * User-facing label for a version. For nightly shows the captured ab build:
+ * `nightly (7.25_ab434)` when nightly info is available, otherwise bare `nightly`.
+ */
+function formatVersionLabel(name) {
+    if (isNightly(name) && _nightlyJsonData?.nightlyVersion) {
+        return `nightly (${_nightlyJsonData.nightlyVersion})`
+    }
+    return name
+}
+
+/**
+ * Label with age suffix for table badges: `nightly (7.25_ab434) · 11h ago`.
+ * Falls back to formatVersionLabel when builtAt is absent.
+ */
+function formatVersionLabelWithAge(name) {
+    if (isNightly(name) && _nightlyJsonData?.nightlyVersion) {
+        const age = formatRelativeAge(_nightlyJsonData.builtAt)
+        const base = `nightly (${_nightlyJsonData.nightlyVersion})`
+        return age ? `${base} · ${age}` : base
+    }
+    return formatVersionLabel(name)
+}
+
+/**
+ * Returns the MIB download URL for a version, or null for nightly (no MIB).
+ */
+function getMibUrl(version) {
+    if (isNightly(version)) return null
+    return `https://download.mikrotik.com/routeros/${version}/mikrotik.mib`
+}
+
+/**
+ * Returns the MikroTik CHANGELOG URL, or the nightly Box share for the synthetic slot.
+ */
+function getChangelogUrl(version) {
+    if (isNightly(version)) return 'https://mt.lv/nightly-build'
+    return `https://download.mikrotik.com/routeros/${version}/CHANGELOG`
+}
+
+/**
+ * Fetch and cache docs/nightly/nightly.json (provenance for the synthetic slot).
+ * Returns the parsed nightly.json object or null if not published / 404.
+ * Cached in memory and localStorage for 5 minutes; falls back to stale cache.
+ */
+function fetchNightlyJson() {
+    if (_nightlyJsonPromise) return _nightlyJsonPromise
+    _nightlyJsonPromise = _fetchNightlyJsonInner()
+    _nightlyJsonPromise.finally(() => { _nightlyJsonPromise = null })
+    return _nightlyJsonPromise
+}
+
+function _fetchNightlyJsonInner() {
+    try {
+        const raw = localStorage.getItem(_NIGHTLY_JSON_CACHE_KEY)
+        if (raw) {
+            const cached = JSON.parse(raw)
+            if (cached?.ts && Date.now() - cached.ts < _NIGHTLY_JSON_TTL && cached.data) {
+                _nightlyJsonData = cached.data
+                return Promise.resolve(cached.data)
+            }
+        }
+    } catch { /* ignore corrupted cache */ }
+
+    const url = `${RESTRAML.pagesUrl}/nightly/nightly.json`
+    return fetch(url)
+        .then(r => {
+            if (!r.ok) {
+                if (r.status === 404) return null
+                const stale = _readStaleNightlyCache()
+                if (stale) return stale
+                throw new Error(`nightly.json ${r.status}`)
+            }
+            return r.json()
+        })
+        .then(data => {
+            if (!data || typeof data.nightlyVersion !== 'string') return null
+            _nightlyJsonData = data
+            try {
+                localStorage.setItem(_NIGHTLY_JSON_CACHE_KEY, JSON.stringify({ ts: Date.now(), data }))
+            } catch { /* storage full */ }
+            return data
+        })
+        .catch(err => {
+            const stale = _readStaleNightlyCache()
+            if (stale) {
+                _nightlyJsonData = stale
+                return stale
+            }
+            // 404 before first publish is expected — not an error.
+            if (err && String(err.message || err).includes('404')) return null
+            throw err
+        })
+}
+
+function _readStaleNightlyCache() {
+    try {
+        const raw = localStorage.getItem(_NIGHTLY_JSON_CACHE_KEY)
+        if (raw) {
+            const cached = JSON.parse(raw)
+            if (cached?.data && typeof cached.data.nightlyVersion === 'string') {
+                return cached.data
+            }
+        }
+    } catch { /* ignore */ }
+    return null
+}
+
+/**
+ * Synchronous accessor for the last fetched nightly.json (or null).
+ * Call after fetchNightlyJson() has resolved.
+ */
+function getCachedNightlyJson() {
+    return _nightlyJsonData
+}
+
+/**
+ * Build a synthetic changelog section for the nightly slot from nightly.json.
+ * Shape matches parseChangelogSections() output so the existing renderers work.
+ */
+function createNightlySyntheticSections(nightlyData) {
+    if (!nightlyData || typeof nightlyData.nightlyVersion !== 'string') return []
+    const dateStr = nightlyData.builtAt
+        ? new Date(nightlyData.builtAt).toLocaleDateString('en-CA')
+        : new Date().toLocaleDateString('en-CA')
+    const heading = `What's new in nightly (${nightlyData.nightlyVersion}) (${dateStr}):`
+    const baseVer = nightlyData.baseVersion || 'stable'
+    const entries = []
+    const x86Count = nightlyData.packages?.x86?.count
+    const arm64Count = nightlyData.packages?.arm64?.count
+    const buildWindow = nightlyData.buildWindow
+    const absent = nightlyData.absentRoots
+
+    entries.push({
+        raw: `*) nightly - Nightly build ${nightlyData.nightlyVersion} from mt.lv/nightly-build (built ${nightlyData.builtAt || ''}, base ${baseVer})`,
+        important: false,
+        secure: false,
+        subsystem: 'nightly',
+        text: `Nightly build ${nightlyData.nightlyVersion} from mt.lv/nightly-build (built ${nightlyData.builtAt || ''}, base ${baseVer}) — single overwritten slot docs/nightly/`,
+    })
+    if (buildWindow?.earliest && buildWindow?.latest) {
+        entries.push({
+            raw: `*) buildWindow - Upload window ${buildWindow.earliest} → ${buildWindow.latest}`,
+            important: false,
+            secure: false,
+            subsystem: 'buildWindow',
+            text: `Upload window ${buildWindow.earliest} → ${buildWindow.latest}`,
+        })
+    }
+    if (Number.isFinite(x86Count) || Number.isFinite(arm64Count)) {
+        const parts = []
+        if (Number.isFinite(x86Count)) parts.push(`x86: ${x86Count} NPKs${nightlyData.packages?.x86?.names ? ` (${nightlyData.packages.x86.names.join(', ')})` : ''}`)
+        if (Number.isFinite(arm64Count)) parts.push(`arm64: ${arm64Count} NPKs${nightlyData.packages?.arm64?.names ? ` (${nightlyData.packages.arm64.names.join(', ')})` : ''}`)
+        entries.push({
+            raw: `*) packages - ${parts.join('; ')}`,
+            important: false,
+            secure: false,
+            subsystem: 'packages',
+            text: parts.join('; '),
+        })
+    }
+    if (Array.isArray(absent) && absent.length > 0) {
+        entries.push({
+            raw: `*) note - extra/ is partial: absent roots ${absent.join(', ')} have no nightly NPKs`,
+            important: false,
+            secure: false,
+            subsystem: 'note',
+            text: `extra/ is partial — absent roots ${absent.join(', ')} have no nightly NPKs on Box, so diff vs release extra shows them as "removed"`,
+        })
+    }
+    entries.push({
+        raw: `*) source - Box share https://mt.lv/nightly-build → https://box.mikrotik.com/d/${nightlyData.source?.token || '5ce46054d5d2487e8755'}/`,
+        important: false,
+        secure: false,
+        subsystem: 'source',
+        text: `Source: mt.lv/nightly-build (Box) — see nightly.json for full provenance`,
+    })
+
+    return [{
+        version: 'nightly',
+        date: dateStr,
+        heading,
+        entries,
+        sourceUrl: 'https://mt.lv/nightly-build',
+    }]
+}
+
+/**
+ * Render an array of changelog sections (as returned by parseChangelogSections
+ * or createNightlySyntheticSections) into contentEl.
+ */
+function renderChangelogSections(sections, query, contentEl, itemCountEl) {
+    const q = query ? query.toLowerCase() : ''
+    let html = ''
+    let totalEntries = 0
+    let visibleEntries = 0
+    let visibleSections = 0
+
+    for (const section of sections) {
+        totalEntries += section.entries.length
+        const headerMatches = q && (
+            section.heading.toLowerCase().includes(q)
+            || section.version.toLowerCase().includes(q)
+            || section.date.toLowerCase().includes(q)
+        )
+        const entries = q
+            ? (headerMatches
+                ? section.entries
+                : section.entries.filter(entry =>
+                    entry.raw.toLowerCase().includes(q)
+                    || entry.subsystem.toLowerCase().includes(q)
+                    || entry.text.toLowerCase().includes(q)
+                ))
+            : section.entries
+
+        if (q && entries.length === 0) continue
+        visibleSections++
+        const sectionLink = section.sourceUrl
+            ? `<a href="${escapeHtml(section.sourceUrl)}" target="_blank" rel="noopener" class="secondary">CHANGELOG ↗</a>`
+            : ''
+        const headerCls = sectionLink ? 'cl-section-header cl-section-header-link' : 'cl-section-header'
+        if (sectionLink) {
+            html += `<span class="${headerCls}"><span>${_clHighlight(section.heading, query)}</span>${sectionLink}</span>`
+        } else {
+            html += `<span class="${headerCls}">${_clHighlight(section.heading, query)}</span>`
+        }
+        for (const entry of entries) {
+            visibleEntries++
+            html += renderChangelogEntryHtml(entry, query)
+        }
+    }
+
+    if (!sections.length) {
+        contentEl.innerHTML = '<p style="opacity:0.65; padding:2rem; text-align:center"><em>No release note sections found.</em></p>'
+        if (itemCountEl) itemCountEl.textContent = ''
+        return
+    }
+    if (!html.trim()) {
+        contentEl.innerHTML = '<p style="opacity:0.65; padding:2rem 0; text-align:center"><em>No matching changelog entries found.</em></p>'
+    } else {
+        contentEl.innerHTML = html
+    }
+    if (itemCountEl) {
+        if (q) {
+            itemCountEl.textContent = `${visibleEntries} of ${totalEntries} entries across ${visibleSections} of ${sections.length} releases match "${query}"`
+        } else {
+            itemCountEl.textContent = `${totalEntries} entries across ${sections.length} release${sections.length === 1 ? '' : 's'}`
+        }
+    }
+}
+
+/**
+ * Fetch changelog sections for a single version. For nightly returns the
+ * synthetic section without hitting download.mikrotik.com (which 404s).
+ */
+async function fetchChangelogSectionsForVersion(version) {
+    if (isNightly(version)) {
+        const nightlyData = _nightlyJsonData || await fetchNightlyJson()
+        if (nightlyData) return createNightlySyntheticSections(nightlyData)
+        // Fallback synthetic when nightly.json hasn't been fetched yet
+        return [{
+            version: 'nightly',
+            date: new Date().toLocaleDateString('en-CA'),
+            heading: `What's new in nightly (synthetic):`,
+            entries: [{
+                raw: '*) nightly - Nightly build from mt.lv/nightly-build (see nightly.json)',
+                important: false,
+                secure: false,
+                subsystem: 'nightly',
+                text: 'Nightly build from mt.lv/nightly-build — see docs/nightly/nightly.json for provenance',
+            }],
+            sourceUrl: 'https://mt.lv/nightly-build',
+        }]
+    }
+    const url = `https://download.mikrotik.com/routeros/${version}/CHANGELOG`
+    const resp = await fetch(url)
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const text = await resp.text()
+    const sections = parseChangelogSections(text)
+    // Annotate sourceUrl for rendering
+    for (const s of sections) s.sourceUrl = url
+    return sections
+}
+
+/**
+ * Filter candidate versions to the changelog range (older, newer].
+ * Excludes synthetic versions (nightly) — they have no CHANGELOG on
+ * download.mikrotik.com and would otherwise make compareVersions(v, 'nightly')
+ * true for every version, pulling the whole history.
+ */
+function getChangelogVersionsInRange(range, allVersions, includeTesting) {
+    const candidateVersions = includeTesting
+        ? allVersions.filter(v => !isNightly(v))
+        : allVersions.filter(v => !isNightly(v) && !isTestingPreRelease(v))
+    if (range.older === range.newer) {
+        return candidateVersions.filter(v => v === range.newer)
+    }
+    return candidateVersions.filter(version =>
+        compareVersions(version, range.newer) >= 0
+        && compareVersions(version, range.older) < 0
+    )
 }
 
 // --- Published docs inventory: fetch version directory listing --------
@@ -171,6 +549,17 @@ function _fetchVersionListInner() {
             try {
                 localStorage.setItem(_VER_CACHE_KEY, JSON.stringify({ ts: Date.now(), data: versions }))
             } catch { /* storage full or unavailable */ }
+            // Opportunistically cache nightly info from docs-index if present
+            if (data.nightly && typeof data.nightly.nightlyVersion === 'string') {
+                // Seed _nightlyJsonData with the minimal nightly fields so badge
+                // can render even before nightly.json is fetched.
+                if (!_nightlyJsonData) {
+                    _nightlyJsonData = {
+                        nightlyVersion: data.nightly.nightlyVersion,
+                        builtAt: data.nightly.builtAt,
+                    }
+                }
+            }
             return versions
         })
         .catch(err => {
@@ -469,22 +858,31 @@ function initChangelogModal(opts) {
 
     searchEl.addEventListener('input', () => {
         if (_rawText) renderChangelogContent(_rawText, _version, searchEl.value.trim(), contentEl, itemCountEl)
+        // For nightly synthetic sections we re-render via sections
+        if (!_rawText && _version === 'nightly' && _nightlyJsonData) {
+            const sections = createNightlySyntheticSections(_nightlyJsonData)
+            renderChangelogSections(sections, searchEl.value.trim(), contentEl, itemCountEl)
+        }
     })
 
     async function showChangelog(version) {
-        const url = `https://download.mikrotik.com/routeros/${version}/CHANGELOG`
+        const isNightlyVersion = isNightly(version)
+        const url = getChangelogUrl(version)
         _version = version
         _rawText = ''
         searchEl.value = ''
-        titleEl.textContent = `RouterOS ${version} — Release Notes`
-        subtitleEl.textContent = ''
+        titleEl.textContent = isNightlyVersion && _nightlyJsonData?.nightlyVersion
+            ? `RouterOS nightly (${_nightlyJsonData.nightlyVersion}) — Release Notes`
+            : `RouterOS ${version} — Release Notes`
+        subtitleEl.textContent = isNightlyVersion && _nightlyJsonData?.builtAt
+            ? new Date(_nightlyJsonData.builtAt).toLocaleString()
+            : ''
         mikrotikLink.href = url
+        mikrotikLink.textContent = isNightlyVersion ? 'mt.lv/nightly-build ↗' : 'CHANGELOG ↗'
         contentEl.innerHTML = '<p aria-busy="true" style="text-align:center; padding:2rem">Loading changelog…</p>'
         itemCountEl.textContent = ''
 
         // Find the previous version for the diff link.
-        // Respects opts.includePre(): if false, skip pre-release versions so
-        // e.g. "7.21.3 → 7.22" is used instead of "7.22rc4 → 7.22".
         const allVers = opts.getVersions()
         const incPre = opts.includePre()
         const idx = allVers.indexOf(version)
@@ -506,6 +904,43 @@ function initChangelogModal(opts) {
         }
 
         modal.showModal()
+
+        // Nightly: synthetic section from nightly.json (no 404)
+        if (isNightlyVersion) {
+            try {
+                const nightlyData = _nightlyJsonData || await fetchNightlyJson()
+                if (nightlyData) {
+                    // Update title/subtitle with fresh nightly data
+                    titleEl.textContent = `RouterOS nightly (${nightlyData.nightlyVersion}) — Release Notes`
+                    subtitleEl.textContent = nightlyData.builtAt ? new Date(nightlyData.builtAt).toLocaleString() : ''
+                    mikrotikLink.href = 'https://mt.lv/nightly-build'
+                    const sections = createNightlySyntheticSections(nightlyData)
+                    renderChangelogSections(sections, '', contentEl, itemCountEl)
+                    if (typeof plausible !== 'undefined') plausible('Changelog View', { props: { version } })
+                    return
+                }
+                // No nightly data yet — show friendly placeholder
+                contentEl.innerHTML = `
+                    <p style="text-align:center; padding:2rem 1rem">
+                        <span style="font-size:2rem">🌙</span><br><br>
+                        Nightly build from <a href="https://mt.lv/nightly-build" target="_blank" rel="noopener">mt.lv/nightly-build</a><br>
+                        No nightly provenance found — docs/nightly/nightly.json not yet published.<br><br>
+                        <a href="https://mt.lv/nightly-build" target="_blank" rel="noopener" role="button">Open nightly share ↗</a>
+                    </p>`
+                itemCountEl.textContent = ''
+                return
+            } catch (err) {
+                console.warn('Nightly synthetic changelog failed', err)
+                contentEl.innerHTML = `
+                    <p style="text-align:center; padding:2rem 1rem">
+                        <span style="font-size:2rem">🌙</span><br><br>
+                        Nightly build from <a href="https://mt.lv/nightly-build" target="_blank" rel="noopener">mt.lv/nightly-build</a><br><br>
+                        <a href="https://mt.lv/nightly-build" target="_blank" rel="noopener" role="button">Open nightly share ↗</a>
+                    </p>`
+                itemCountEl.textContent = ''
+                return
+            }
+        }
 
         try {
             const response = await fetch(url)
@@ -680,8 +1115,22 @@ Object.assign(window, {
     parseVersion,
     compareVersions,
     isPreRelease,
+    isNightly,
+    isTestingPreRelease,
+    shouldShowVersion,
     rebuildSelect,
     fetchVersionList,
+    fetchNightlyJson,
+    getCachedNightlyJson,
+    formatVersionLabel,
+    formatVersionLabelWithAge,
+    formatRelativeAge,
+    getMibUrl,
+    getChangelogUrl,
+    createNightlySyntheticSections,
+    renderChangelogSections,
+    fetchChangelogSectionsForVersion,
+    getChangelogVersionsInRange,
     initThemeSwitcher,
     renderChangelogEntryHtml,
     parseChangelogSections,


### PR DESCRIPTION
Implements the deferred N5 UI branches for the single-slot `docs/nightly/` from #90 — the publish-only N4 left three 404s and a bare `nightly` label.

## What was broken

* **`nightly` label** — dropdowns and the downloads table showed bare `nightly` with no `ab` build and no age. With a daily (sometimes slower) cron the slot routinely lags the Box share by one or more `ab` builds.
* **Release notes** — `download.mikrotik.com/routeros/nightly/CHANGELOG` is a 404. Clicking the version in the table, the diff range panel, and lookup all showed the CORS-error fallback.
* **MIB** — `index.html:~447` built `…/nightly/mikrotik.mib` — 404 for the synthetic slot.
* **Range query** — `diff.html:getChangelogVersionsInRange` used `compareVersions(v,"nightly")>=0` which is true for every version, so a `nightly ↔ 7.24rc4` diff pulled the whole changelog history.
* **Toggle** — `nightly` is `isPreRelease==true`, so it was hidden behind "include testing". Shared links needed `?testing=true` to make `nightly` selectable, which dumps ~30 beta/rc entries on someone who only wanted nightly.
* **Guides** — `diff` vs release `extra/` renders 2,325 nodes (≈5.6 % of the tree) as "removed" — those are the four roots (`dude`, `user-manager`, `openflow`, `tr069-client`) that have no nightly NPKs on the Box share at all.

## Changes

### `docs/restraml-shared.js` — shared nightly helpers (N5)

* `fetchNightlyJson()` — fetches `docs/nightly/nightly.json` (provenance for the synthetic slot), cached in memory + `localStorage` for 5 min, `404→null` so the site works before the first nightly publish. `docs-index.json:nightly` is still read opportunistically to seed the badge.
* `isNightly()` / `isTestingPreRelease()` / `shouldShowVersion()` — split the old `isPreRelease` (which conflated `beta`/`rc`/`nightly`) so testing and nightly can be toggled independently.
* `formatVersionLabel("nightly") → "nightly (7.25_ab434)"` and `formatVersionLabelWithAge → "nightly (7.25_ab434) · 11h ago"` via `formatRelativeAge(builtAt)`.
* `getMibUrl()` → `null` for nightly, `getChangelogUrl()` → `https://mt.lv/nightly-build` for nightly.
* `createNightlySyntheticSections()` — one synthetic `What's new in nightly (7.25_ab434) (date):` section from `nightly.json` (`nightlyVersion`, `builtAt`, `baseVersion`, `packages.{x86,arm64}`, `buildWindow`, `absentRoots`, `source`) and `renderChangelogSections()`.
* `fetchChangelogSectionsForVersion("nightly")` — early-returns the synthetic section (no 404), and `getChangelogVersionsInRange()` — always excludes synthetic so `compareVersions(v,"nightly")>=0` does not pull whole history.
* `rebuildSelect()` — now takes `{includeTesting,includeNightly}` (boolean `showAll` still works for callers that haven't migrated) and renders the nightly badge when `getCachedNightlyJson()` is available.
* `initChangelogModal` — for nightly shows the synthetic title `RouterOS nightly (7.25_ab434) — Release Notes` + builtAt subtitle + `mt.lv/nightly-build ↗` link; search re-renders the synthetic sections.

### `docs/index.html`

* Row: `nightly (7.25_ab434) · 11h ago` (via `formatVersionLabelWithAge`, `title` with age), `href` → `mt.lv`, MIB → `n/a · Box share`, `/app` YAML suppressed for nightly (only `docs/nightly/app.json` is published — N6).
* Two new `include nightly` toggles (diff selects + downloads table), each wired with `{includeTesting,includeNightly}` and `writeQueryParams` now emits `?nightly=true`. `applyQueryParams` auto-enables nightly when `?compare*=nightly` is present.
* `fetchVersionList` now `Promise.all(... fetchNightlyJson())` and `refreshNightlyLabels()` after the badge loads.

### `docs/diff.html`

* Same two-flag selects + `?nightly`, `getChangelogVersionsInRange` delegates to the shared helper, `fetchChangelogSectionsForVersion` returns the synthetic section for nightly, `loadRangeChangelog` prepends the synthetic nightly section when the range touches nightly and the error fallback points to `mt.lv`. Batch fetch is nightly-aware and the badge refreshes after `nightly.json` loads.

### `docs/lookup.html` / `docs/openapi.html`

* `include nightly` toggle, `rebuildVersionSelect` uses `shouldShowVersion` + `formatVersionLabel`, version links use `getChangelogUrl()` + badge, query strings gain `nightly`. `lookup` extra picks the per-arch `deep-inspect.x86.json` variant for nightly extra. Guides note that nightly `extra/` is partial.

### Guides

* `diff` and `lookup` "behind the curtain" now note that nightly `extra/` has no NPKs for `dude`/`user-manager`/`openflow`/`tr069-client`, so a diff vs release extra showing those roots as "removed" is not a real removal.

## Verification

* `bunx tsc --noEmit` — 0 errors (now typechecks `scripts/` as of N3)
* `bunx @biomejs/biome check .` — 0 errors (33 files)
* `bun test` — `228 pass / 0 fail` (includes `version-primitives.test.ts` parity)
* `actionlint` — 9 workflow files pass
* Manual: `nightly (7.25_ab434) · age` renders in all four pages, `?nightly=true` and `?compare*=nightly` share links auto-enable, changelog modal shows the synthetic section, MIB cell shows `n/a`, diff range no longer pulls whole history.

Refs #90, N4 `c2eec4b` (#95), N3 `626d3bd` (#93), N2 `80fa3be` (#92), N1 `578042d` (#91).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added nightly-version support across schema comparisons, lookups, OpenAPI exploration, and documentation tools.
  - Added nightly filters, version selectors, labels, build-age details, and URL state persistence.
  - Added nightly package availability with automatic fallback when specialized files are unavailable.
  - Added nightly changelog notes, range handling, tooltips, and fallback states.
  - Added synchronized nightly selection between comparison and schema views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->