### PR TITLE
Validate nightly /app against latest schema and file issue (N6) (#90)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -511,19 +511,23 @@ jobs:
           bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json
           EXIT_CODE=$?
           echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
-          if [ $EXIT_CODE -eq 1 ]; then
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✓ nightly /app validation clean"
+            exit 0
+          elif [ $EXIT_CODE -eq 2 ]; then
+            echo "::warning::Nightly /app validation: $EXIT_CODE — some apps do not conform to latest schema (issue will be filed)"
+            exit 0
+          elif [ $EXIT_CODE -eq 1 ]; then
             echo "::error::JSON Schema meta-validation failed — schemas are invalid"
             exit 1
+          else
+            echo "::error::Unexpected validator exit code $EXIT_CODE — failing (expected 0, 1, or 2)"
+            exit 1
           fi
-          if [ $EXIT_CODE -eq 2 ]; then
-            echo "::warning::Nightly /app validation: $EXIT_CODE — some apps do not conform to latest schema (issue will be filed)"
-          fi
-          # Exit 0 and 2 are both publish-able; the issue is the signal, not a gate.
-          exit 0
 
       - name: Create GitHub issue for nightly /app validation failures
         if: steps.validate-nightly-app.outputs.exit_code == '2'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           APP_YAML_FAILURES_FILE: ${{ runner.temp }}/app-yaml-failures-nightly.txt
           NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
@@ -544,6 +548,7 @@ jobs:
             } catch (e) {}
             // Count failures from the details file (one per line starting with "- `")
             const failCount = failureDetails.split('\n').filter(l => l.trim().startsWith('- `')).length
+            const title = `Nightly ${nightlyVersion}: /app YAML schema validation failures (vs latest)`
             const body = [
               `## Nightly ${nightlyVersion}: /app YAML schema validation failures (vs \`latest\`)`,
               '',
@@ -571,14 +576,41 @@ jobs:
               `[View run logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
             ].join('\n')
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Nightly ${nightlyVersion}: /app YAML schema validation failures (vs latest)`,
-              body,
-              labels: ['bug', 'app-yaml-schema', 'nightly'],
-            })
-            console.log(`Created GitHub issue for nightly ${nightlyVersion} — ${failCount} failures`)
+            // Idempotency: avoid duplicate issues on reruns of the same nightly version
+            let existingIssue = null
+            try {
+              const q = `repo:${context.repo.owner}/${context.repo.repo} "${title}" in:title is:open`
+              const search = await github.rest.search.issuesAndPullRequests({ q })
+              if (search.data.total_count > 0) existingIssue = search.data.items[0]
+            } catch (e) {
+              console.log(`Search failed, falling back to create: ${e.message}`)
+            }
+
+            if (existingIssue) {
+              const issueNumber = existingIssue.number
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  `Rerun for **${nightlyVersion}** — still failing (${failCount} of ${nightlyMeta}):`,
+                  '',
+                  failureDetails,
+                  '',
+                  `[View run logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                ].join('\n')
+              })
+              console.log(`Updated existing issue #${issueNumber} for nightly ${nightlyVersion} — ${failCount} failures (rerun)`)
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug', 'app-yaml-schema', 'nightly'],
+              })
+              console.log(`Created GitHub issue for nightly ${nightlyVersion} — ${failCount} failures`)
+            }
 
       - name: Upload nightly /app validation failures
         if: always() && steps.validate-nightly-app.outputs.exit_code == '2'

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -419,6 +419,81 @@ jobs:
           fi
 
           ls -lh docs/nightly/ docs/nightly/extra/
+      - name: Diff x86 vs arm64 extra
+        run: |
+          set -euo pipefail
+          echo "=== Text diff (x86 vs arm64 extra) ==="
+          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json | tee /tmp/diff.txt
+          echo ""
+          echo "=== JSON diff ==="
+          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json --json > docs/nightly/extra/diff-deep-inspect.json
+          echo "diff-deep-inspect.json: $(du -h docs/nightly/extra/diff-deep-inspect.json | cut -f1)"
+
+      - name: Verify diff is not a relabeled copy
+        run: |
+          set -euo pipefail
+          ARM64_ONLY=$(jq '.counts.pathsOnlyB' docs/nightly/extra/diff-deep-inspect.json)
+          X86_ONLY=$(jq '.counts.pathsOnlyA' docs/nightly/extra/diff-deep-inspect.json)
+          echo "Paths only in arm64: $ARM64_ONLY"
+          echo "Paths only in x86:   $X86_ONLY"
+          # Without this, a shape change that makes jq emit null turns the gate
+          # below into a silent pass ([ null -lt 500 ] errors, `if` reads false).
+          case "$ARM64_ONLY" in
+            ''|*[!0-9]*) echo "::error::pathsOnlyB is not a number ('$ARM64_ONLY') — diff JSON shape changed"; exit 1 ;;
+          esac
+          # Reference: full all_packages builds run ~1,561 arm64-only paths
+          # (docs/7.24rc2/extra/diff-deep-inspect.json); nightly's arm64 NPK set
+          # is larger than its x86 one, so 500 is a floor with real headroom.
+          if [ "$ARM64_ONLY" -lt 500 ]; then
+            echo "::error::arm64 has only $ARM64_ONLY unique paths (expected ≥500) — relabeled x86 or truncated crawl"
+            exit 1
+          fi
+
+      - name: Generate aggregated nightly.json
+        run: |
+          set -euo pipefail
+          bun -e '
+          import fs from "node:fs";
+          const r = (p) => JSON.parse(fs.readFileSync(p, "utf8"));
+          const xBase = r("/tmp/nightly-stage/nightly-x86-base/nightly.json");
+          const xExtra = r("/tmp/nightly-stage/nightly-x86-extra/nightly.json");
+          const aExtra = r("/tmp/nightly-stage/nightly-arm64-extra/nightly.json");
+          // nightlyVersion must agree; take max by compareAb if they differ (race where Box rolled between jobs)
+          const versions = [xExtra.nightlyVersion, aExtra.nightlyVersion];
+          const parseAb = (v) => { const m = v.match(/^(\d+)\.(\d+)(?:\.(\d+))?_ab(\d+)$/); return m ? [Number(m[1]), Number(m[2]), Number(m[3]??0), Number(m[4])] : null; };
+          const compareAb = (a,b) => { const pa=parseAb(a), pb=parseAb(b); if(!pa&&!pb) return a.localeCompare(b); if(!pa) return 1; if(!pb) return -1; for(let i=0;i<4;i++) if(pa[i]!==pb[i]) return pa[i]-pb[i]; return 0; };
+          const nightlyVersion = [...versions].sort(compareAb).at(-1);
+          // buildWindow: earliest = min, latest = max across both arches
+          const windows = [xExtra.buildWindow, aExtra.buildWindow].filter(Boolean);
+          const allTimes = windows.flatMap(w => [w.earliest, w.latest]).filter(Boolean).sort();
+          const buildWindow = allTimes.length ? { earliest: allTimes[0], latest: allTimes[allTimes.length-1] } : null;
+          // provenance: take source from xExtra (token etc) — they should match
+          const source = xExtra.source ?? aExtra.source;
+          const baseVersion = xExtra.baseVersion ?? xBase.baseVersion;
+          const builtAt = new Date().toISOString();
+          // Use the most recent builtAt among provenances? No — use publish time
+          const aggregated = {
+            nightlyVersion,
+            builtAt,
+            baseVersion,
+            source,
+            buildWindow,
+            packages: {
+              x86: { count: xExtra.packageCount, names: xExtra.packageNames, npks: xExtra.packages?.npks ?? [], phaseFiles: xExtra.phaseFiles },
+              arm64: { count: aExtra.packageCount, names: aExtra.packageNames, npks: aExtra.packages?.npks ?? [], phaseFiles: aExtra.phaseFiles },
+              rejected: xExtra.packages?.rejected ?? aExtra.packages?.rejected ?? [],
+            },
+            absentRoots: xExtra.absentRoots ?? ["dude","openflow","tr069-client","user-manager"],
+            // Full provenance per arch for debugging
+            provenance: { x86: { base: xBase, extra: xExtra }, arm64: { extra: aExtra } },
+          };
+          fs.mkdirSync("docs/nightly", { recursive: true });
+          fs.writeFileSync("docs/nightly/nightly.json", JSON.stringify(aggregated, null, 2) + "\n");
+          console.log(JSON.stringify(aggregated, null, 2));
+          // Also update nightlyVersion in discover output check for next run — already done
+          '
+          cat docs/nightly/nightly.json | jq .
+
 
       - name: Validate nightly /app YAMLs against latest schema (N6)
         id: validate-nightly-app
@@ -507,86 +582,11 @@ jobs:
 
       - name: Upload nightly /app validation failures
         if: always() && steps.validate-nightly-app.outputs.exit_code == '2'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-app-yaml-failures-${{ needs.discover.outputs.nightly_version }}
           path: ${{ runner.temp }}/app-yaml-failures-nightly.txt
           retention-days: 14
-
-      - name: Diff x86 vs arm64 extra
-        run: |
-          set -euo pipefail
-          echo "=== Text diff (x86 vs arm64 extra) ==="
-          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json | tee /tmp/diff.txt
-          echo ""
-          echo "=== JSON diff ==="
-          bun scripts/diff-deep-inspect.ts docs/nightly/extra/deep-inspect.x86.json docs/nightly/extra/deep-inspect.arm64.json --json > docs/nightly/extra/diff-deep-inspect.json
-          echo "diff-deep-inspect.json: $(du -h docs/nightly/extra/diff-deep-inspect.json | cut -f1)"
-
-      - name: Verify diff is not a relabeled copy
-        run: |
-          set -euo pipefail
-          ARM64_ONLY=$(jq '.counts.pathsOnlyB' docs/nightly/extra/diff-deep-inspect.json)
-          X86_ONLY=$(jq '.counts.pathsOnlyA' docs/nightly/extra/diff-deep-inspect.json)
-          echo "Paths only in arm64: $ARM64_ONLY"
-          echo "Paths only in x86:   $X86_ONLY"
-          # Without this, a shape change that makes jq emit null turns the gate
-          # below into a silent pass ([ null -lt 500 ] errors, `if` reads false).
-          case "$ARM64_ONLY" in
-            ''|*[!0-9]*) echo "::error::pathsOnlyB is not a number ('$ARM64_ONLY') — diff JSON shape changed"; exit 1 ;;
-          esac
-          # Reference: full all_packages builds run ~1,561 arm64-only paths
-          # (docs/7.24rc2/extra/diff-deep-inspect.json); nightly's arm64 NPK set
-          # is larger than its x86 one, so 500 is a floor with real headroom.
-          if [ "$ARM64_ONLY" -lt 500 ]; then
-            echo "::error::arm64 has only $ARM64_ONLY unique paths (expected ≥500) — relabeled x86 or truncated crawl"
-            exit 1
-          fi
-
-      - name: Generate aggregated nightly.json
-        run: |
-          set -euo pipefail
-          bun -e '
-          import fs from "node:fs";
-          const r = (p) => JSON.parse(fs.readFileSync(p, "utf8"));
-          const xBase = r("/tmp/nightly-stage/nightly-x86-base/nightly.json");
-          const xExtra = r("/tmp/nightly-stage/nightly-x86-extra/nightly.json");
-          const aExtra = r("/tmp/nightly-stage/nightly-arm64-extra/nightly.json");
-          // nightlyVersion must agree; take max by compareAb if they differ (race where Box rolled between jobs)
-          const versions = [xExtra.nightlyVersion, aExtra.nightlyVersion];
-          const parseAb = (v) => { const m = v.match(/^(\d+)\.(\d+)(?:\.(\d+))?_ab(\d+)$/); return m ? [Number(m[1]), Number(m[2]), Number(m[3]??0), Number(m[4])] : null; };
-          const compareAb = (a,b) => { const pa=parseAb(a), pb=parseAb(b); if(!pa&&!pb) return a.localeCompare(b); if(!pa) return 1; if(!pb) return -1; for(let i=0;i<4;i++) if(pa[i]!==pb[i]) return pa[i]-pb[i]; return 0; };
-          const nightlyVersion = [...versions].sort(compareAb).at(-1);
-          // buildWindow: earliest = min, latest = max across both arches
-          const windows = [xExtra.buildWindow, aExtra.buildWindow].filter(Boolean);
-          const allTimes = windows.flatMap(w => [w.earliest, w.latest]).filter(Boolean).sort();
-          const buildWindow = allTimes.length ? { earliest: allTimes[0], latest: allTimes[allTimes.length-1] } : null;
-          // provenance: take source from xExtra (token etc) — they should match
-          const source = xExtra.source ?? aExtra.source;
-          const baseVersion = xExtra.baseVersion ?? xBase.baseVersion;
-          const builtAt = new Date().toISOString();
-          // Use the most recent builtAt among provenances? No — use publish time
-          const aggregated = {
-            nightlyVersion,
-            builtAt,
-            baseVersion,
-            source,
-            buildWindow,
-            packages: {
-              x86: { count: xExtra.packageCount, names: xExtra.packageNames, npks: xExtra.packages?.npks ?? [], phaseFiles: xExtra.phaseFiles },
-              arm64: { count: aExtra.packageCount, names: aExtra.packageNames, npks: aExtra.packages?.npks ?? [], phaseFiles: aExtra.phaseFiles },
-              rejected: xExtra.packages?.rejected ?? aExtra.packages?.rejected ?? [],
-            },
-            absentRoots: xExtra.absentRoots ?? ["dude","openflow","tr069-client","user-manager"],
-            // Full provenance per arch for debugging
-            provenance: { x86: { base: xBase, extra: xExtra }, arm64: { extra: aExtra } },
-          };
-          fs.mkdirSync("docs/nightly", { recursive: true });
-          fs.writeFileSync("docs/nightly/nightly.json", JSON.stringify(aggregated, null, 2) + "\n");
-          console.log(JSON.stringify(aggregated, null, 2));
-          // Also update nightlyVersion in discover output check for next run — already done
-          '
-          cat docs/nightly/nightly.json | jq .
 
       - name: Rebuild docs-index.json
         run: bun scripts/build-docs-index.mjs

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -322,6 +322,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -404,20 +405,113 @@ jobs:
           cp /tmp/nightly-stage/nightly-arm64-extra/deep-inspect.arm64.json docs/nightly/extra/deep-inspect.arm64.json
           # arm64 openapi is not published as canonical extra/openapi.json (keep x86 as canonical)
 
-          # app.json — only from extra where container is present. Published raw,
-          # unvalidated: nightly is expected to run ahead of the /app schema, and
-          # per-version schema generation for nightly is deferred (N6). The old
-          # block here only re-checked that our own committed schema was valid
-          # JSON Schema — it never looked at app.json — so it is gone rather than
-          # left in place implying coverage that does not exist.
+          # app.json — only from extra where container is present. Staged for
+          # N6 offline validation against docs/routeros-app-yaml-schema.latest.json
+          # (no per-version schemas under docs/nightly/ — that would mint a stable
+          # $id with daily-changing content). Validation runs in the next step;
+          # the file is published even when validation fails so the failure artifact
+          # is debuggable — the issue is the signal, not a publish gate.
           if [ -f /tmp/nightly-stage/nightly-x86-extra/app.json ]; then
             cp /tmp/nightly-stage/nightly-x86-extra/app.json docs/nightly/extra/app.json
-            echo "→ app.json: $(jq 'length' docs/nightly/extra/app.json) entries from x86 extra (published raw, not schema-validated)"
+            echo "→ app.json: $(jq 'length' docs/nightly/extra/app.json) entries from x86 extra (staged for N6 validation)"
           else
             echo "::warning::no app.json from x86 extra — container package may be absent this build"
           fi
 
           ls -lh docs/nightly/ docs/nightly/extra/
+
+      - name: Validate nightly /app YAMLs against latest schema (N6)
+        id: validate-nightly-app
+        env:
+          APP_YAML_FAILURES_FILE: ${{ runner.temp }}/app-yaml-failures-nightly.txt
+        run: |
+          set +e
+          rm -f "$APP_YAML_FAILURES_FILE"
+          if [ ! -f docs/nightly/extra/app.json ]; then
+            echo "::warning::docs/nightly/extra/app.json not found — skipping /app validation"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "→ validating docs/nightly/extra/app.json against latest schema (offline, --no-schema-write)"
+          bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json
+          EXIT_CODE=$?
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+          if [ $EXIT_CODE -eq 1 ]; then
+            echo "::error::JSON Schema meta-validation failed — schemas are invalid"
+            exit 1
+          fi
+          if [ $EXIT_CODE -eq 2 ]; then
+            echo "::warning::Nightly /app validation: $EXIT_CODE — some apps do not conform to latest schema (issue will be filed)"
+          fi
+          # Exit 0 and 2 are both publish-able; the issue is the signal, not a gate.
+          exit 0
+
+      - name: Create GitHub issue for nightly /app validation failures
+        if: steps.validate-nightly-app.outputs.exit_code == '2'
+        uses: actions/github-script@v9
+        env:
+          APP_YAML_FAILURES_FILE: ${{ runner.temp }}/app-yaml-failures-nightly.txt
+          NIGHTLY_VERSION: ${{ needs.discover.outputs.nightly_version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+            const nightlyVersion = process.env.NIGHTLY_VERSION || 'unknown'
+            const failuresPath = process.env.APP_YAML_FAILURES_FILE
+            let failureDetails = '(no details file found)'
+            try {
+              failureDetails = fs.readFileSync(failuresPath, 'utf8')
+            } catch (e) {}
+            let nightlyMeta = ''
+            try {
+              const j = JSON.parse(fs.readFileSync('docs/nightly/extra/app.json', 'utf8'))
+              nightlyMeta = `${j.length} entries`
+            } catch (e) {}
+            // Count failures from the details file (one per line starting with "- `")
+            const failCount = failureDetails.split('\n').filter(l => l.trim().startsWith('- `')).length
+            const body = [
+              `## Nightly ${nightlyVersion}: /app YAML schema validation failures (vs \`latest\`)`,
+              '',
+              `Nightly **${nightlyVersion}** built-in \`/app\` entries failed validation against`,
+              '`docs/routeros-app-yaml-schema.latest.json` (`docs/routeros-app-yaml-store-schema.latest.json`).',
+              '',
+              'This is the **early-warning channel** for the next beta/RC promotion — the same',
+              'failures would have blocked `appyamlschemas.yaml` on the next versioned build.',
+              'The schema should be updated to allow the new syntax (or the upstream app YAML',
+              'fixed) and re-validated. `docs/nightly/extra/app.json` is still published as the',
+              'debuggable raw artifact.',
+              '',
+              `### Failing /app entries (${failCount} of ${nightlyMeta})`,
+              '',
+              failureDetails,
+              '',
+              '### Provenance',
+              '',
+              `\`docs/nightly/nightly.json\` at publish time:`,
+              '```json',
+              (() => { try { return fs.readFileSync('docs/nightly/nightly.json', 'utf8').slice(0, 4000) } catch(e) { return '(unavailable before publish)' } })(),
+              '```',
+              '',
+              `### Workflow run`,
+              `[View run logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n')
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly ${nightlyVersion}: /app YAML schema validation failures (vs latest)`,
+              body,
+              labels: ['bug', 'app-yaml-schema', 'nightly'],
+            })
+            console.log(`Created GitHub issue for nightly ${nightlyVersion} — ${failCount} failures`)
+
+      - name: Upload nightly /app validation failures
+        if: always() && steps.validate-nightly-app.outputs.exit_code == '2'
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-app-yaml-failures-${{ needs.discover.outputs.nightly_version }}
+          path: ${{ runner.temp }}/app-yaml-failures-nightly.txt
+          retention-days: 14
 
       - name: Diff x86 vs arm64 extra
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -527,6 +527,7 @@ jobs:
 
       - name: Create GitHub issue for nightly /app validation failures
         if: steps.validate-nightly-app.outputs.exit_code == '2'
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           APP_YAML_FAILURES_FILE: ${{ runner.temp }}/app-yaml-failures-nightly.txt
@@ -576,14 +577,21 @@ jobs:
               `[View run logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
             ].join('\n')
 
-            // Idempotency: avoid duplicate issues on reruns of the same nightly version
+            // Idempotency: avoid duplicate issues on reruns of the same nightly version.
+            // Use listForRepo + local title match instead of search (immune to
+            // search-index lag and fragile query quoting for titles with \`:\`, \`/app\`, \`(vs latest)\`).
             let existingIssue = null
             try {
-              const q = `repo:${context.repo.owner}/${context.repo.repo} "${title}" in:title is:open`
-              const search = await github.rest.search.issuesAndPullRequests({ q })
-              if (search.data.total_count > 0) existingIssue = search.data.items[0]
+              const { data: openIssues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'nightly,app-yaml-schema',
+                per_page: 100
+              })
+              existingIssue = openIssues.find(i => i.title === title) || null
             } catch (e) {
-              console.log(`Search failed, falling back to create: ${e.message}`)
+              console.log(`List failed, falling back to create: ${e.message}`)
             }
 
             if (existingIssue) {

--- a/appyamlvalidate.js
+++ b/appyamlvalidate.js
@@ -349,15 +349,10 @@ async function main() {
     console.log(`Fetched ${apps.length} built-in /app entries from router`)
 
     // Save raw /app JSON to docs/<version>/app.json for reference and debugging
-    // (skip when --no-schema-write? No — offline nightly already has the file;
-    // live path still writes as before unless suppressed.)
-    if (!noSchemaWrite) {
-      const appJsonPathLive = resolveDocsPath(version, "app.json")
-      writeJsonFile(appJsonPathLive, apps)
-      console.log(`Written: ${appJsonPathLive}`)
-    } else {
-      console.log(`Skipping app.json write (--no-schema-write) — ${apps.length} entries fetched`)
-    }
+    // Always write — --no-schema-write only suppresses per-version schema files.
+    const appJsonPathLive = resolveDocsPath(version, "app.json")
+    writeJsonFile(appJsonPathLive, apps)
+    console.log(`Written: ${appJsonPathLive}`)
   } catch (err) {
     console.error(`::warning::Failed to fetch /app list: ${err.message}`)
     console.log("Skipping live /app YAML validation due to fetch error")

--- a/appyamlvalidate.js
+++ b/appyamlvalidate.js
@@ -5,6 +5,10 @@
 // Usage:
 //   bun appyamlvalidate.js <version>
 //   URLBASE=http://localhost:9180/rest BASICAUTH=admin: bun appyamlvalidate.js 7.22
+//   bun appyamlvalidate.js <version> --no-schema-write --app-json docs/nightly/extra/app.json
+//
+// Offline nightly example (no live CHR, no per-version schemas):
+//   bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json
 //
 // Environment variables:
 //   URLBASE     - RouterOS REST API base URL (enables live /app validation)
@@ -80,16 +84,82 @@ function assertAppList(value) {
   return value
 }
 
+function printUsageAndExit(code = 0) {
+  console.log(
+    [
+      "Usage: bun appyamlvalidate.js <version> [options]",
+      "",
+      "  <version>                    RouterOS version (e.g. 7.22, 7.24rc4, nightly)",
+      "",
+      "Options:",
+      "  --no-schema-write            Skip writing per-version schemas to docs/<version>/",
+      "                               (validates base schemas in place; use for nightly)",
+      "  --app-json <path>            Validate apps from a JSON file instead of GET /rest/app",
+      "                               (offline mode; e.g. docs/nightly/extra/app.json)",
+      "  --help                       Show this help",
+      "",
+      "Examples:",
+      "  bun appyamlvalidate.js 7.22",
+      "  URLBASE=http://localhost:9180/rest BASICAUTH=admin: bun appyamlvalidate.js 7.22",
+      "  bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json",
+    ].join("\n")
+  )
+  process.exit(code)
+}
+
 async function main() {
-  const args = Bun.argv.slice(2)
-  const versionArg = args[0]
+  const rawArgs = Bun.argv.slice(2)
+
+  // --- Flag parsing (positional <version> + --no-schema-write + --app-json) ---
+  let versionArg = null
+  let noSchemaWrite = false
+  let appJsonPath = null
+  let help = false
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const a = rawArgs[i]
+    if (a === "--help" || a === "-h") {
+      help = true
+    } else if (a === "--no-schema-write") {
+      noSchemaWrite = true
+    } else if (a === "--app-json") {
+      const next = rawArgs[i + 1]
+      if (!next || next.startsWith("-")) {
+        console.error("Error: --app-json requires a file path")
+        process.exit(1)
+      }
+      appJsonPath = next
+      i++
+    } else if (a.startsWith("--app-json=")) {
+      appJsonPath = a.slice("--app-json=".length)
+      if (!appJsonPath) {
+        console.error("Error: --app-json requires a file path")
+        process.exit(1)
+      }
+    } else if (a.startsWith("-")) {
+      console.error(`Unknown option: ${a}`)
+      console.error("Usage: bun appyamlvalidate.js <version> [--no-schema-write] [--app-json <path>]")
+      process.exit(1)
+    } else if (versionArg === null) {
+      versionArg = a
+    } else {
+      console.error(`Unexpected argument: ${a}`)
+      console.error("Usage: bun appyamlvalidate.js <version> [--no-schema-write] [--app-json <path>]")
+      process.exit(1)
+    }
+  }
+
+  if (help) printUsageAndExit(0)
 
   if (!versionArg) {
-    console.error("Usage: bun appyamlvalidate.js <version>")
+    console.error("Usage: bun appyamlvalidate.js <version> [--no-schema-write] [--app-json <path>]")
     process.exit(1)
   }
 
   const version = assertSafeVersion(versionArg)
+
+  // Allow --app-json to point anywhere; validate that the path stays readable.
+  // No path-traversal guard needed beyond existence check — it is a read, not a write.
 
   // --- Load base schemas ---
   const singleSchema = JSON.parse(fs.readFileSync(SINGLE_SCHEMA_PATH, "utf8"))
@@ -111,15 +181,19 @@ async function main() {
     },
   }
 
-  // --- Write per-version schemas to docs/<version>/ ---
-  const docsPath = resolveDocsPath(version)
-  fs.mkdirSync(docsPath, { recursive: true })
-  const singleOutputPath = resolveDocsPath(version, "routeros-app-yaml-schema.json")
-  const storeOutputPath = resolveDocsPath(version, "routeros-app-yaml-store-schema.json")
-  writeJsonFile(singleOutputPath, versionedSingleSchema)
-  writeJsonFile(storeOutputPath, versionedStoreSchema)
-  console.log(`Written: ${singleOutputPath}`)
-  console.log(`Written: ${storeOutputPath}`)
+  // --- Write per-version schemas to docs/<version>/ (unless --no-schema-write) ---
+  if (!noSchemaWrite) {
+    const docsPath = resolveDocsPath(version)
+    fs.mkdirSync(docsPath, { recursive: true })
+    const singleOutputPath = resolveDocsPath(version, "routeros-app-yaml-schema.json")
+    const storeOutputPath = resolveDocsPath(version, "routeros-app-yaml-store-schema.json")
+    writeJsonFile(singleOutputPath, versionedSingleSchema)
+    writeJsonFile(storeOutputPath, versionedStoreSchema)
+    console.log(`Written: ${singleOutputPath}`)
+    console.log(`Written: ${storeOutputPath}`)
+  } else {
+    console.log("Skipping per-version schema write (--no-schema-write)")
+  }
 
   // --- Part 1: Validate schemas against JSON Schema meta-schema ---
   console.log("\n=== Part 1: JSON Schema meta-validation ===")
@@ -130,7 +204,12 @@ async function main() {
 
   let schemaErrors = false
 
-  const singleValid = ajv.validateSchema(versionedSingleSchema)
+  // When --no-schema-write, validate the base schemas directly (no versioned $id needed).
+  // Otherwise validate the versioned schemas as before.
+  const singleToValidate = noSchemaWrite ? singleSchema : versionedSingleSchema
+  const storeToValidate = noSchemaWrite ? storeSchemaBase : versionedStoreSchema
+
+  const singleValid = ajv.validateSchema(singleToValidate)
   if (!singleValid) {
     console.error(
       "✗ routeros-app-yaml-schema.json is NOT valid JSON Schema:"
@@ -141,9 +220,10 @@ async function main() {
     console.log("✓ routeros-app-yaml-schema.json is valid JSON Schema")
   }
 
-  // Add the single schema so the store schema's $ref can resolve
-  ajv.addSchema(versionedSingleSchema)
-  const storeValid = ajv.validateSchema(versionedStoreSchema)
+  // Add the single schema so the store schema's $ref can resolve.
+  // Use the matching variant (base vs versioned) consistently.
+  ajv.addSchema(noSchemaWrite ? singleSchema : versionedSingleSchema)
+  const storeValid = ajv.validateSchema(storeToValidate)
   if (!storeValid) {
     console.error(
       "✗ routeros-app-yaml-store-schema.json is NOT valid JSON Schema:"
@@ -159,12 +239,86 @@ async function main() {
   }
 
   // --- Part 2: Validate built-in RouterOS /app YAMLs against schema ---
+  // Offline file takes precedence over live fetch; both paths share the same validator.
   const urlbase = process.env.URLBASE
   const basicauth = process.env.BASICAUTH
 
+  // Choose validator schema consistently with Part 1 (base vs versioned)
+  const validateSchema = noSchemaWrite ? singleSchema : versionedSingleSchema
+
+  if (appJsonPath) {
+    console.log(`\n=== Part 2: Validating /app YAMLs from file: ${appJsonPath} ===`)
+    let apps
+    try {
+      const raw = fs.readFileSync(appJsonPath, "utf8")
+      apps = assertAppList(JSON.parse(raw))
+      console.log(`Loaded ${apps.length} /app entries from ${appJsonPath}`)
+    } catch (err) {
+      console.error(`Failed to read --app-json file '${appJsonPath}': ${err.message}`)
+      process.exit(1)
+    }
+
+    const validate = ajv.compile(validateSchema)
+    const failures = []
+
+    for (const app of apps) {
+      const appName = app.name || app[".id"] || "unknown"
+      const yamlStr = app.yaml
+      if (!yamlStr) {
+        console.log(`  ⚠ ${appName}: no 'yaml' field found, skipping`)
+        continue
+      }
+
+      let parsed
+      try {
+        parsed = YAML.load(yamlStr)
+      } catch (err) {
+        const msg = `YAML parse error: ${err.message}`
+        console.error(`  ✗ ${appName}: ${msg}`)
+        failures.push({ name: appName, summary: msg })
+        continue
+      }
+
+      const valid = validate(parsed)
+      if (!valid) {
+        const errSummary = (validate.errors || [])
+          .map((e) => `${e.instancePath || "/"} ${e.message}`)
+          .join("; ")
+        console.error(`  ✗ ${appName}: ${errSummary}`)
+        failures.push({ name: appName, summary: errSummary })
+      } else {
+        console.log(`  ✓ ${appName}`)
+      }
+    }
+
+    if (failures.length > 0) {
+      console.error(
+        `\n${failures.length} /app YAML(s) failed schema validation (from ${appJsonPath}):`
+      )
+      for (const f of failures) {
+        console.error(`  - ${f.name}: ${f.summary}`)
+      }
+      const failureLines = failures
+        .map(
+          (f) =>
+            `- \`${sanitizeFailureField(f.name)}\`: ${sanitizeFailureField(f.summary)}`
+        )
+        .join("\n")
+      const failureFilePath = path.resolve(FAILURES_FILE)
+      writeTextFile(failureFilePath, `${failureLines}\n`)
+      console.error(`Failure details written to ${failureFilePath}`)
+      process.exit(2)
+    }
+
+    console.log(
+      `\n✓ All ${apps.length} /app YAMLs from ${appJsonPath} validated successfully`
+    )
+    process.exit(0)
+  }
+
   if (!urlbase) {
     console.log(
-      "\n=== Part 2: Skipped (URLBASE not set — no live router available) ==="
+      "\n=== Part 2: Skipped (URLBASE not set and --app-json not provided — no live router available) ==="
     )
     process.exit(0)
   }
@@ -195,16 +349,22 @@ async function main() {
     console.log(`Fetched ${apps.length} built-in /app entries from router`)
 
     // Save raw /app JSON to docs/<version>/app.json for reference and debugging
-    const appJsonPath = resolveDocsPath(version, "app.json")
-    writeJsonFile(appJsonPath, apps)
-    console.log(`Written: ${appJsonPath}`)
+    // (skip when --no-schema-write? No — offline nightly already has the file;
+    // live path still writes as before unless suppressed.)
+    if (!noSchemaWrite) {
+      const appJsonPathLive = resolveDocsPath(version, "app.json")
+      writeJsonFile(appJsonPathLive, apps)
+      console.log(`Written: ${appJsonPathLive}`)
+    } else {
+      console.log(`Skipping app.json write (--no-schema-write) — ${apps.length} entries fetched`)
+    }
   } catch (err) {
     console.error(`::warning::Failed to fetch /app list: ${err.message}`)
     console.log("Skipping live /app YAML validation due to fetch error")
     process.exit(0)
   }
 
-  const validate = ajv.compile(versionedSingleSchema)
+  const validate = ajv.compile(validateSchema)
   const failures = []
 
   for (const app of apps) {

--- a/appyamlvalidate.js
+++ b/appyamlvalidate.js
@@ -158,8 +158,8 @@ async function main() {
 
   const version = assertSafeVersion(versionArg)
 
-  // Allow --app-json to point anywhere; validate that the path stays readable.
-  // No path-traversal guard needed beyond existence check — it is a read, not a write.
+  // --app-json is a read-only input; existence/readability is checked via
+  // the try/catch around fs.readFileSync when the file is loaded (L296).
 
   // --- Load base schemas ---
   const singleSchema = JSON.parse(fs.readFileSync(SINGLE_SCHEMA_PATH, "utf8"))


### PR DESCRIPTION
Implements N6 from #90 — nightly early-warning for `/app` schema drift, now **with issue filing** per updated policy.

Nightly already publishes `docs/nightly/extra/app.json` raw (108 entries on `7.25_ab434`). Validating it offline against `docs/routeros-app-yaml-schema.latest.json` gives a one-day early warning before the same apps would block `appyamlschemas.yaml` on the next `beta`/`rc` promotion. The previous plan suppressed filing (concern about daily noise); @amm0 now prefers the signal — a nightly `latest`-vs-`app.json` mismatch is worth a report even if it fires once per `ab` build, since it surfaces gaps before the versioned pipeline does.

## Current nightly proves the value

| Version | Apps | Failures vs `latest` |
|---------|------|----------------------|
| `7.24rc4` / `7.23.3` | 108 / 104 | 0 |
| `7.25_ab434` (nightly) | 108 | **6** |

Failing apps: `cryptpad` (`ulimits.nofile` as `"1000000"`), `goaway` (`command` contains boolean `true`), `inventree`/`mikrodash`/`onlyoffice-docs` (`healthcheck.retries` as `"5"`), `zulip` (ports as objects + `ulimits`). Nightly surfaces these during the `ab` train instead of waiting for `7.25beta`.

## Changes

### `appyamlvalidate.js` — offline validate-only mode

- `--no-schema-write` — skips writing per-version schemas to `docs/<version>/` (avoids minting a stable `$id` with daily-changing content) and validates the base schemas in place.
- `--app-json <path>` — validates apps from a JSON file (array from `GET /rest/app`) instead of `GET /rest/app` — keeps the existing `URLBASE` live path.
- Both flags share the same exit-code contract (`0` clean, `1` meta-fail, `2` app failures) and `APP_YAML_FAILURES_FILE` handling.
- `nightly --no-schema-write --app-json` now reports the 6 failures above; `--no-schema-write` leaves `docs/nightly/` untouched; `URLBASE` live path unchanged.
- `--help` and unknown-option handling.

### `.github/workflows/nightly.yaml` — publish-nightly now validates after Assemble

- After `Assemble docs/nightly/` (so `docs/nightly/extra/app.json` exists): `bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json` (captures `exit_code`, `1`→hard fail, `2`→warn).
- On `exit_code == 2`: `actions/github-script` files a GitHub issue:
  ```
  title: Nightly 7.25_ab434: /app YAML schema validation failures (vs latest)
  labels: [bug, app-yaml-schema, nightly]
  body: nightlyVersion + 108 entries + fail list + nightly.json snippet + run link
  ```
  Uploads the failures file as `nightly-app-yaml-failures-<ver>` (14d). Publish stays **green** — the issue is the signal, not a gate — so `docs/nightly/extra/app.json` is still published as the debuggable raw artifact. Adds `issues: write` to job permissions.
- Updates the `app.json` comment to reflect N6 staging vs “raw, unvalidated”.

## Verification

- `bun test` — 228 pass
- `bunx tsc --noEmit` — 0
- `bunx @biomejs/biome check .` — 0 (33 files)
- `bun validate-workflows.mjs` — 9 workflows pass
- Offline nightly validation: `APP_YAML_FAILURES_FILE=/tmp/t bun appyamlvalidate.js nightly --no-schema-write --app-json docs/nightly/extra/app.json` → exit 2, 6 failures; `docs/nightly/routeros*` not created; live `URLBASE` path still skips cleanly without the flags.

Next cron will file the first nightly early-warning issue instead of waiting for `7.25beta`. A cheap dedup (“comment instead of open if an open nightly issue already exists for this failure signature”) can be added later if daily noise warrants it.

Refs #90, N5 `b6377a5` (#98), N4 `c2eec4b` (#95).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline validation for application metadata using the latest schemas.
  * Added command-line options for help, application metadata input, and controlling schema output.
  * Added support for consistently validating both base and versioned schemas.

* **Bug Fixes**
  * Improved handling of missing validation data by skipping checks when appropriate.
  * Ensured invalid schemas fail validation while non-schema data mismatches remain publishable.

* **Chores**
  * Validation failures now generate detailed reports and retained artifacts for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->