### PR TITLE
Bump x86 nightly budget and record slot-contents decisions (N7) (#90)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -131,7 +131,14 @@ jobs:
     needs: discover
     if: needs.discover.outputs.changed == 'true' && needs.discover.outputs.nightly_version != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # 55 min, not 40: this job is the long pole because it runs two phases
+    # (base then extra) on one runner. First green run (7.25_ab434) took
+    # 30.2 min, leaving under 10 min of headroom — a slow MikroTik CDN day on
+    # the stable CHR image download (70 s observed, and it is fetched once per
+    # phase before the image cache warms) is the realistic way that gets eaten.
+    # Extra budget is free on a job that normally finishes early; a timeout
+    # here costs a whole nightly. arm64 stays at 60 (used 21.7 min).
+    timeout-minutes: 55
     permissions:
       contents: read
     # No MIKROTIK_* license secrets here: quickchr only licenses when passed

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -132,12 +132,14 @@ jobs:
     if: needs.discover.outputs.changed == 'true' && needs.discover.outputs.nightly_version != ''
     runs-on: ubuntu-latest
     # 55 min, not 40: this job is the long pole because it runs two phases
-    # (base then extra) on one runner. First green run (7.25_ab434) took
-    # 30.2 min, leaving under 10 min of headroom — a slow MikroTik CDN day on
-    # the stable CHR image download (70 s observed, and it is fetched once per
-    # phase before the image cache warms) is the realistic way that gets eaten.
-    # Extra budget is free on a job that normally finishes early; a timeout
-    # here costs a whole nightly. arm64 stays at 60 (used 21.7 min).
+    # (base then extra) on one runner. First green run (7.25_ab434, run
+    # 31743491114) took 30.2 min, leaving under 10 min of headroom. The
+    # realistic way that gets eaten is a slow MikroTik CDN day on the stable
+    # CHR image: the download is paid once per cold runner (70 s observed —
+    # phase 1 booted in 95.9 s, phase 2 in 24.2 s from quickchr's image cache),
+    # so a bad CDN day inflates the one leg the job cannot skip. Extra budget
+    # is free on a job that normally finishes early; a timeout here costs a
+    # whole nightly. arm64 stays at 60 (used 21.7 min).
     timeout-minutes: 55
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1005,9 +1005,9 @@ Rules that are easy to get wrong:
   `bun link` in `../quickchr` then `bun link @tikoci/quickchr` here — do not re-add the `file:`
   dependency to `package.json`.
 - **The slot keeps `openapi.json` and `schema.raml`.** They are ~27 MB of the ~35 MB base slot, so
-  dropping them was considered for storage — but `openapi.json` is a live consumer
-  (`openapi.html?version=nightly&nightly=true` serves it), and `schema.raml` stays for parity with
-  every versioned build. Consecutive `ab` builds are near-identical, so the single-slot git delta
+  dropping them was considered for storage — but `docs/openapi.html` is a live consumer of the
+  slot's `openapi.json` (`openapi.html?version=nightly&nightly=true` loads it), and `schema.raml`
+  stays for parity with every versioned build. Consecutive `ab` builds are near-identical, so the single-slot git delta
   is small (~4.5 MiB of objects for the first ~85 MB publish). If RAML generation is ever retired
   repo-wide, the nightly slot follows that decision — it is not a nightly-specific call.
 - **`/app` is validated offline against the root `*.latest.json`**, never per-version. Minting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1004,6 +1004,19 @@ Rules that are easy to get wrong:
   fails the install outright. To iterate against a local quickchr working copy, use
   `bun link` in `../quickchr` then `bun link @tikoci/quickchr` here — do not re-add the `file:`
   dependency to `package.json`.
+- **The slot keeps `openapi.json` and `schema.raml`.** They are ~27 MB of the ~35 MB base slot, so
+  dropping them was considered for storage — but `openapi.json` is a live consumer
+  (`openapi.html?version=nightly&nightly=true` serves it), and `schema.raml` stays for parity with
+  every versioned build. Consecutive `ab` builds are near-identical, so the single-slot git delta
+  is small (~4.5 MiB of objects for the first ~85 MB publish). If RAML generation is ever retired
+  repo-wide, the nightly slot follows that decision — it is not a nightly-specific call.
+- **`/app` is validated offline against the root `*.latest.json`**, never per-version. Minting
+  `docs/nightly/routeros-app-yaml-schema.json` would create a stable `$id` URL whose content
+  changes daily, breaking schema identity and editor caching. The validation step runs in
+  `publish-nightly` *after* `nightly.json` is aggregated (so the filed issue embeds real
+  provenance) and is `continue-on-error` — a drift issue is the early-warning signal for the next
+  beta/RC promotion, not a publish gate. `app.json` publishes either way as the debuggable raw
+  artifact.
 
 ### `auto.yaml` — `skip_versions` Input
 


### PR DESCRIPTION
Final N7 slice for #90. The remaining work after the first green nightly run was a budget headroom fix plus two decisions left open in the thread.

## Budget

`nightly-x86` `timeout-minutes` 40 → **55**. That job is the long pole because it runs `base` then `extra` on one runner:

| Job | Used | Budget | Headroom |
|---|---|---|---|
| x86 (base + extra) | 30.2 min | 40 | **9.8 min** |
| arm64 (extra) | 21.7 min | 60 | 38.3 min |
| publish | 0.9 min | 10 | 9.1 min |

(measured on [run 31743491114](https://github.com/tikoci/restraml/actions/runs/31743491114), `7.25_ab434`)

The realistic way <10 min gets eaten is a slow MikroTik CDN day on the stable CHR image download — 70 s observed, and it is fetched once per phase before the image cache warms. Extra budget is free on a job that normally finishes early; a timeout costs a whole nightly. arm64 and publish are left alone.

## Decisions recorded in CLAUDE.md

- **`openapi.json` and `schema.raml` stay in the slot.** Dropping them was considered for storage (~27 MB of the ~35 MB base slot), but `openapi.html?version=nightly&nightly=true` is a live consumer of `openapi.json`, and `schema.raml` stays for parity with every versioned build. If RAML generation is ever retired repo-wide the nightly slot follows that decision — it is not a nightly-specific call.
- **`/app` validation shape** (from N6 / #99): offline against the root `*.latest.json`, never per-version (a `docs/nightly/routeros-app-yaml-schema.json` would mint a stable `$id` URL with daily-changing content); runs after `nightly.json` is aggregated so the filed issue embeds real provenance; `continue-on-error` because the drift issue is the early-warning signal, not a publish gate.

## N7's other line items

Already done or moot — the `?nightly=true` toggle landed in N5 (#98), and `history.json` is covered by `git log -- docs/nightly/`.

`228 pass / tsc 0 / biome 0 / actionlint 9 pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)