### PR TITLE
Fix arm64 package activation: restore SCP + explicit reboot (#96)

### DIFF
--- a/.github/actions/activate-chr-license/action.yml
+++ b/.github/actions/activate-chr-license/action.yml
@@ -1,0 +1,176 @@
+name: Activate CHR trial license
+description: >
+  Apply a p1 trial license to a running CHR, detect real failures in the response
+  body, and raise a standing GitHub issue when licensing degrades to free tier.
+
+# Why this is not a bare curl: POST /rest/system/license/renew answers HTTP 200
+# for BOTH outcomes. The body is a progress array whose last element carries the
+# verdict:
+#   success  [... {".section":"5","status":"done"}]
+#   failure  [... {".section":"5","status":"ERROR: Licensing Error: too many trial licences"}]
+# The previous inline `curl ... && echo "License activated"` therefore reported
+# success on every run, including the ones that were actually running free-tier
+# at 1 Mbit/s. Parse the body, never the exit code.
+#
+# Degradation is never fatal: a free-tier CHR produces a CORRECT crawl, just a
+# slower one. It is a cost/latency signal, not a correctness one.
+
+inputs:
+  account:
+    description: MikroTik web account. Step no-ops when empty.
+    required: false
+    default: ""
+  password:
+    description: MikroTik web account password.
+    required: false
+    default: ""
+  rest-url:
+    description: Base REST URL of the running CHR.
+    required: false
+    default: http://admin:@localhost:9180/rest
+  level:
+    description: License level to request.
+    required: false
+    default: p1
+  timeout:
+    description: curl timeout in seconds. Raise this for TCG-emulated guests.
+    required: false
+    default: "10"
+  arch:
+    description: Architecture label, used only in log and issue text.
+    required: true
+  github-token:
+    description: Token used to raise the standing degradation issue. Empty disables issue filing.
+    required: false
+    default: ""
+
+outputs:
+  degraded:
+    description: Empty when the license applied; otherwise the reason reported by RouterOS.
+    value: ${{ steps.renew.outputs.degraded }}
+
+runs:
+  using: composite
+  steps:
+    - name: Renew CHR license
+      id: renew
+      shell: bash
+      env:
+        MT_ACCOUNT: ${{ inputs.account }}
+        MT_PASSWORD: ${{ inputs.password }}
+        REST_URL: ${{ inputs.rest-url }}
+        LEVEL: ${{ inputs.level }}
+        CURL_TIMEOUT: ${{ inputs.timeout }}
+        ARCH: ${{ inputs.arch }}
+      run: |
+        set -uo pipefail
+
+        if [ -z "$MT_ACCOUNT" ]; then
+          echo "No MikroTik account configured — running free tier (1 Mbit/s)."
+          echo "degraded=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        RESP=$(curl -sS -m "$CURL_TIMEOUT" -X POST "${REST_URL}/system/license/renew" \
+          -H 'Content-Type: application/json' \
+          -d "$(jq -nc --arg a "$MT_ACCOUNT" --arg p "$MT_PASSWORD" --arg l "$LEVEL" \
+                '{account:$a,password:$p,level:$l}')" 2>/dev/null) || RESP=""
+
+        # Last progress row carries the verdict; tolerate a bare object too.
+        STATUS=$(printf '%s' "$RESP" | jq -r '
+          if type == "array" and length > 0 then (.[-1].status // "")
+          elif type == "object" then (.status // "")
+          else "" end' 2>/dev/null) || STATUS=""
+
+        if [ "$STATUS" = "done" ]; then
+          echo "✓ License activated (${LEVEL} trial) on ${ARCH}."
+          echo "degraded=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        REASON="${STATUS:-no usable response from /system/license/renew}"
+        echo "::warning::${ARCH}: license activation failed (${REASON}) — continuing at free tier (1 Mbit/s). Output stays correct, enrichment is slower."
+        {
+          echo "### ⚠ ${ARCH}: CHR licensing degraded to free tier"
+          echo ""
+          echo "\`${REASON}\`"
+          echo ""
+          echo "The crawl is still correct — only slower (1 Mbit/s)."
+        } >> "$GITHUB_STEP_SUMMARY"
+        echo "degraded=${REASON}" >> "$GITHUB_OUTPUT"
+
+    - name: Raise standing licensing issue
+      if: steps.renew.outputs.degraded != '' && inputs.github-token != ''
+      continue-on-error: true
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        DEGRADED_REASON: ${{ steps.renew.outputs.degraded }}
+        ARCH: ${{ inputs.arch }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          // Deliberately create-if-absent WITHOUT commenting on reruns. Unlike the
+          // nightly /app failures — which are version-specific and episodic — an
+          // exhausted trial pool is a persistent condition, so a daily comment would
+          // be pure noise. The open issue is the standing signal; per-run detail
+          // lives in the job summary. Both arch jobs may reach here: the first
+          // creates, the rest find it and skip.
+          const title = 'deep-inspect multi-arch: CHR trial licensing degraded to free tier'
+          const reason = process.env.DEGRADED_REASON || '(unknown)'
+          const arch = process.env.ARCH || 'unknown'
+          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+          let existing = null
+          try {
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci,licensing',
+              per_page: 100,
+            })
+            existing = open.find(i => i.title === title) || null
+          } catch (e) {
+            console.log(`List failed, falling back to create: ${e.message}`)
+          }
+
+          if (existing) {
+            console.log(`Standing issue #${existing.number} already open — not commenting (persistent condition).`)
+            return
+          }
+
+          const body = [
+            `## CHR trial licensing is degrading to free tier`,
+            '',
+            `\`deep-inspect-multi-arch.yaml\` could not apply a **p1** trial license. RouterOS reported:`,
+            '',
+            '```',
+            reason,
+            '```',
+            '',
+            `First observed on the **${arch}** job in [this run](${runUrl}).`,
+            '',
+            '### Impact',
+            '',
+            'Builds still produce **correct** output — a free-tier CHR is throttled to 1 Mbit/s,',
+            'so enrichment is slower and timing baselines in `docs/deep-inspect.md` no longer',
+            'compare like-for-like. This is a cost/latency signal, not a correctness one, and it',
+            'is deliberately **not** a build failure.',
+            '',
+            '### To resolve',
+            '',
+            '- Point `MIKROTIK_ACCOUNT` / `MIKROTIK_PASSWORD` at an account with trials available, or',
+            '- accept free-tier runs and close this issue.',
+            '',
+            'This issue is raised once and left open as a standing signal — reruns do **not**',
+            'add comments. Per-run detail is in each job summary.',
+          ].join('\n')
+
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title,
+            body,
+            labels: ['ci', 'licensing'],
+          })
+          console.log(`Created standing licensing issue (first seen on ${arch}).`)

--- a/.github/actions/activate-chr-license/action.yml
+++ b/.github/actions/activate-chr-license/action.yml
@@ -120,13 +120,16 @@ runs:
           const arch = process.env.ARCH || 'unknown'
           const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
 
+          // Match on title alone — deliberately NOT filtered by label. Labels are
+          // decoration; if one were ever renamed or removed, a label-filtered
+          // lookup would quietly stop finding the standing issue and start
+          // opening a duplicate on every degraded run.
           let existing = null
           try {
-            const { data: open } = await github.rest.issues.listForRepo({
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'ci,licensing',
               per_page: 100,
             })
             existing = open.find(i => i.title === title) || null
@@ -137,6 +140,29 @@ runs:
           if (existing) {
             console.log(`Standing issue #${existing.number} already open — not commenting (persistent condition).`)
             return
+          }
+
+          // Create the labels if absent. `ci` and `licensing` do not exist in this
+          // repo yet, and issues.create rejects unknown labels — with
+          // continue-on-error above, that would silently mean no issue at all.
+          const labels = ['ci', 'licensing']
+          for (const name of labels) {
+            try {
+              await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name })
+            } catch {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: 'ededed',
+                  description: name === 'ci' ? 'CI workflow behaviour' : 'CHR licensing / trial pool',
+                })
+                console.log(`Created missing label "${name}".`)
+              } catch (e) {
+                console.log(`Could not create label "${name}": ${e.message}`)
+              }
+            }
           }
 
           const body = [
@@ -166,11 +192,15 @@ runs:
             'add comments. Per-run detail is in each job summary.',
           ].join('\n')
 
-          await github.rest.issues.create({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            title,
-            body,
-            labels: ['ci', 'licensing'],
-          })
+          // Never lose the issue over a label problem — retry bare.
+          try {
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo, title, body, labels,
+            })
+          } catch (e) {
+            console.log(`Create with labels failed (${e.message}) — retrying without labels.`)
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo, title, body,
+            })
+          }
           console.log(`Created standing licensing issue (first seen on ${arch}).`)

--- a/.github/workflows/deep-inspect-multi-arch.yaml
+++ b/.github/workflows/deep-inspect-multi-arch.yaml
@@ -60,8 +60,9 @@ jobs:
           ls -la /dev/kvm
 
       - name: Download CHR x86 image
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          VER="${{ inputs.rosver }}"
           wget -q "https://download.mikrotik.com/routeros/${VER}/chr-${VER}.vdi.zip" -O chr.vdi.zip \
             || (rm -f chr.vdi.zip && wget -q "https://cdn.mikrotik.com/routeros/${VER}/chr-${VER}.vdi.zip" -O chr.vdi.zip)
           unzip -q chr.vdi.zip
@@ -124,8 +125,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download and install extra packages
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          VER="${{ inputs.rosver }}"
           mkdir extra && cd extra
           wget -q "https://download.mikrotik.com/routeros/${VER}/all_packages-x86-${VER}.zip" \
             || wget -q "https://cdn.mikrotik.com/routeros/${VER}/all_packages-x86-${VER}.zip"
@@ -302,8 +304,9 @@ jobs:
           fi
 
       - name: Download CHR arm64 image
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          VER="${{ inputs.rosver }}"
           wget -q "https://download.mikrotik.com/routeros/${VER}/chr-${VER}-arm64.img.zip" -O chr-arm64.img.zip \
             || (rm -f chr-arm64.img.zip && wget -q "https://cdn.mikrotik.com/routeros/${VER}/chr-${VER}-arm64.img.zip" -O chr-arm64.img.zip)
           unzip -q chr-arm64.img.zip
@@ -315,8 +318,9 @@ jobs:
         # Same source and primary/fallback order as the x86 job. Stable releases
         # live only on download.mikrotik.com; beta/rc only on cdn.mikrotik.com.
         # Do not reorder these two hosts.
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          VER="${{ inputs.rosver }}"
           mkdir extra && cd extra
           wget -q "https://download.mikrotik.com/routeros/${VER}/all_packages-arm64-${VER}.zip" \
             || wget -q "https://cdn.mikrotik.com/routeros/${VER}/all_packages-arm64-${VER}.zip"
@@ -603,8 +607,10 @@ jobs:
           echo "✓ arm64 structural delta looks legitimate ($ARM64_ONLY arm64-only paths)"
 
       - name: Generate step summary
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          echo "### Deep-Inspect Multi-Arch: ${{ inputs.rosver }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Deep-Inspect Multi-Arch: ${VER}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
@@ -617,8 +623,9 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Publish deep-inspect files to docs
+        env:
+          VER: ${{ inputs.rosver }}
         run: |
-          VER="${{ inputs.rosver }}"
           DOCS_PATH="docs/${VER}/extra"
           mkdir -p "$DOCS_PATH"
           cp deep-inspect.x86.json "$DOCS_PATH/"

--- a/.github/workflows/deep-inspect-multi-arch.yaml
+++ b/.github/workflows/deep-inspect-multi-arch.yaml
@@ -124,7 +124,9 @@ jobs:
           timeout: "10"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download and install extra packages
+      - name: Download x86 extra packages
+        # Stable releases live only on download.mikrotik.com; beta/rc only on
+        # cdn.mikrotik.com. Do not reorder these two hosts.
         env:
           VER: ${{ inputs.rosver }}
         run: |
@@ -132,7 +134,21 @@ jobs:
           wget -q "https://download.mikrotik.com/routeros/${VER}/all_packages-x86-${VER}.zip" \
             || wget -q "https://cdn.mikrotik.com/routeros/${VER}/all_packages-x86-${VER}.zip"
           unzip -q all_packages*.zip && rm all_packages*.zip && cd ..
+          echo "Packages to inject: $(find extra -name '*.npk' | wc -l)"
+          ls -lh extra/*.npk
+
+      - name: Install extra packages via SCP
+        # SLIRP runs in the QEMU host process — it is unaffected by guest events.
+        # RouterOS installs any .npk found at flash root on the next boot, so the
+        # activation trigger is the explicit reboot in the next step — never
+        # /system/package/apply-changes, which prompts and defaults to no (#96).
+        # Bounded so a slow-upload regression fails fast instead of quietly
+        # consuming the job budget (see the arm64 job for the 2026-04 precedent).
+        timeout-minutes: 15
+        run: |
+          started=$(date +%s)
           scp -o StrictHostKeyChecking=no -P 9122 extra/* admin@localhost:/
+          echo "Uploaded $(find extra -name '*.npk' | wc -l) NPK(s) in $(( $(date +%s) - started ))s."
 
       - name: Reboot CHR and wait for extra packages
         run: |
@@ -409,8 +425,10 @@ jobs:
           account: ${{ secrets.MIKROTIK_ACCOUNT }}
           password: ${{ secrets.MIKROTIK_PASSWORD }}
           arch: arm64
-          # TCG guests answer slowly through the emulated TCP stack.
-          timeout: ${{ env.ARM_ACCEL == 'kvm' && '10' || '30' }}
+          # Flat 30s rather than branching on ARM_ACCEL: this is a ceiling, not a
+          # sleep, so a KVM guest that answers in under a second is unaffected —
+          # and TCG guests answer slowly through the emulated TCP stack.
+          timeout: "30"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install extra packages via SCP

--- a/.github/workflows/deep-inspect-multi-arch.yaml
+++ b/.github/workflows/deep-inspect-multi-arch.yaml
@@ -23,6 +23,15 @@ on:
         description: 'RouterOS Version (e.g. 7.22.1, 7.23beta5)'
         required: true
 
+# Package-provided top-level menus that MUST appear in the crawled tree once the
+# all_packages set is installed and ACTIVE. Both arches ship all six, so a missing
+# one means the packages never activated rather than a schema delta (#96).
+# Deliberately excluded: /app (needs container + RouterOS 7.22+) and /caps-man
+# (wireless-package dependent) — both vary by version, so they would make this
+# gate version-sensitive for no diagnostic gain.
+env:
+  REQUIRED_ROOTS: container,iot,dude,user-manager,tr069-client,openflow
+
 jobs:
   # ── x86 deep-inspect (KVM, fast) ─────────────────────────────────────────
   deep-inspect-x86:
@@ -31,11 +40,11 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      # For the standing licensing-degradation issue (activate-chr-license).
+      issues: write
     env:
       URLBASE: http://localhost:9180/rest
       BASICAUTH: "admin:"
-      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
-      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -106,13 +115,13 @@ jobs:
           exit 1
 
       - name: Activate CHR trial license
-        if: env.MIKROTIK_ACCOUNT != ''
-        run: |
-          curl -sS -X POST http://admin:@localhost:9180/rest/system/license/renew \
-            -H 'Content-Type: application/json' \
-            -d "{\"account\":\"${MIKROTIK_ACCOUNT}\",\"password\":\"${MIKROTIK_PASSWORD}\",\"level\":\"p1\"}" \
-            && echo "License activated to p1 (trial)" \
-            || echo "::warning::License activation failed — enrichment will run at 1 Mbit/s (free)"
+        uses: ./.github/actions/activate-chr-license
+        with:
+          account: ${{ secrets.MIKROTIK_ACCOUNT }}
+          password: ${{ secrets.MIKROTIK_PASSWORD }}
+          arch: x86
+          timeout: "10"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download and install extra packages
         run: |
@@ -125,6 +134,9 @@ jobs:
 
       - name: Reboot CHR and wait for extra packages
         run: |
+          # A reboot that never happens is the #96 failure mode: packages stay
+          # listed-but-inactive, every gate downstream still passes, and the crawl
+          # silently loses thousands of args. Never let this fall through quietly.
           wait_for_rest_down() {
             for i in $(seq 1 15); do
               if ! curl -sS -m 3 --fail http://localhost:9180/ > /dev/null 2>&1; then
@@ -133,7 +145,8 @@ jobs:
               fi
               sleep 2
             done
-            echo "::warning::REST API never visibly went down after reboot request; continuing with readiness wait."
+            echo "::error::CHR never went down after the reboot request — extra packages will NOT be active (see #96)."
+            return 1
           }
 
           wait_for_rest_ready() {
@@ -165,7 +178,7 @@ jobs:
             -H 'Content-Type: application/json' > /dev/null 2>&1 || \
             ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -p 9122 admin@localhost /system/reboot > /dev/null 2>&1 || true
 
-          wait_for_rest_down
+          wait_for_rest_down || { tail -40 /tmp/qemu.log || true; exit 1; }
           echo "Waiting for x86 CHR to restart with extra packages (up to 240s)..."
           if wait_for_rest_ready 48; then
             exit 0
@@ -194,7 +207,8 @@ jobs:
         # workflow-local (if: always() on Upload) until harnesses converge.
         run: |
           bun deep-inspect.ts --live --arch x86 --output-suffix x86 \
-            --output-dir . --skip-openapi --test-crash-paths --transport rest
+            --output-dir . --skip-openapi --test-crash-paths --transport rest \
+            --require-roots "$REQUIRED_ROOTS"
 
       - name: Verify x86 deep-inspect output
         run: |
@@ -232,19 +246,26 @@ jobs:
   # crashing the REST server. Local TCG with 1024 MB: 44ms child, 71ms
   # completion — projecting ~10 min for full deep-inspect.
   #
-  # Package installation uses REST /execute (check-for-updates + enable +
-  # apply-changes). This works under both KVM and TCG — no SCP needed.
+  # Package installation uses the SAME mechanism as the x86 job: download the
+  # all_packages-arm64 zip, SCP the NPKs to flash root, then issue an EXPLICIT
+  # /system/reboot. Do not replace this with a REST /execute script that ends in
+  # /system/package/apply-changes (see #96): apply-changes prompts
+  # "Apply scheduled changes and reboot device? [y/N]" and defaults to N, so the
+  # reboot silently never fires. The packages stay listed-but-inactive,
+  # /system/package still reports 19 entries, and the crawl quietly loses ~8000
+  # args across /app /caps-man /container /dude /iot /openflow /tr069-client
+  # /user-manager. That is exactly how this job broke from 2026-07-28 onward.
   deep-inspect-arm64:
     name: "arm64: ${{ inputs.rosver }}"
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     permissions:
       contents: read
+      # For the standing licensing-degradation issue (activate-chr-license).
+      issues: write
     env:
       URLBASE: http://localhost:9180/rest
       BASICAUTH: "admin:"
-      MIKROTIK_ACCOUNT: ${{ secrets.MIKROTIK_ACCOUNT }}
-      MIKROTIK_PASSWORD: ${{ secrets.MIKROTIK_PASSWORD }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -289,6 +310,19 @@ jobs:
           mv chr-*-arm64.img chr-arm64.img
           rm -f chr-arm64.img.zip
           ls -lh chr-arm64.img
+
+      - name: Download arm64 extra packages
+        # Same source and primary/fallback order as the x86 job. Stable releases
+        # live only on download.mikrotik.com; beta/rc only on cdn.mikrotik.com.
+        # Do not reorder these two hosts.
+        run: |
+          VER="${{ inputs.rosver }}"
+          mkdir extra && cd extra
+          wget -q "https://download.mikrotik.com/routeros/${VER}/all_packages-arm64-${VER}.zip" \
+            || wget -q "https://cdn.mikrotik.com/routeros/${VER}/all_packages-arm64-${VER}.zip"
+          unzip -q all_packages*.zip && rm all_packages*.zip && cd ..
+          echo "Packages to inject: $(find extra -name '*.npk' | wc -l)"
+          ls -lh extra/*.npk
 
       - name: Start arm64 CHR in QEMU
         # CRITICAL aarch64 rules:
@@ -366,33 +400,36 @@ jobs:
           exit 1
 
       - name: Activate CHR trial license
-        if: env.MIKROTIK_ACCOUNT != ''
-        run: |
-          if [ "${ARM_ACCEL}" = "kvm" ]; then CURL_T=10; else CURL_T=30; fi
-          curl -sS -m "$CURL_T" -X POST http://admin:@localhost:9180/rest/system/license/renew \
-            -H 'Content-Type: application/json' \
-            -d "{\"account\":\"${MIKROTIK_ACCOUNT}\",\"password\":\"${MIKROTIK_PASSWORD}\",\"level\":\"p1\"}" \
-            && echo "License activated (p1 trial)" \
-            || echo "::warning::License activation failed — running at 1 Mbit/s (free)"
+        uses: ./.github/actions/activate-chr-license
+        with:
+          account: ${{ secrets.MIKROTIK_ACCOUNT }}
+          password: ${{ secrets.MIKROTIK_PASSWORD }}
+          arch: arm64
+          # TCG guests answer slowly through the emulated TCP stack.
+          timeout: ${{ env.ARM_ACCEL == 'kvm' && '10' || '30' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install extra packages via REST
-        # POST /rest/execute dispatches an async RouterOS script that:
-        #   1. check-for-updates — downloads available packages via SLIRP
-        #   2. enable [find] — enables all discovered packages
-        #   3. delay 5s — let package state settle
-        #   4. apply-changes — triggers automatic reboot
-        # Fire-and-forget: curl returns immediately, script runs on the CHR.
+      - name: Install extra packages via SCP
+        # SLIRP runs in the QEMU host process — it is unaffected by guest events.
+        # SCP uploads directly to the CHR filesystem, same approach as x86 job.
+        # RouterOS installs any .npk found at flash root on the next boot, so the
+        # activation trigger is the explicit reboot in the next step — never
+        # /system/package/apply-changes, which prompts and defaults to no (#96).
+        #
+        # Expect ~1 min: nightly.yaml pushes a comparable 52 MiB of NPKs to an
+        # arm64 TCG CHR at 1024 MB and completes upload+reboot+boot in ~64s. The
+        # 52-MINUTE SCP seen in April 2026 (run 24553141540) was the 256 MB
+        # memory-pressure artifact, not SCP being unsuited to TCG. The bound
+        # below exists so a return of that pressure fails fast instead of
+        # quietly consuming the job's 60-minute budget.
+        timeout-minutes: 15
         run: |
-          if [ "${ARM_ACCEL}" = "kvm" ]; then CURL_T=10; else CURL_T=30; fi
-          curl -sS -m "$CURL_T" -X POST http://admin:@localhost:9180/rest/execute \
-            -H 'Content-Type: application/json' \
-            -d '{"script":"/system/package/update/check-for-updates duration=15s; /system/package/enable [find]; :delay 5s; /system/package/apply-changes","as-string":"true"}' \
-            && echo "Package install script dispatched (async — CHR will reboot)" \
-            || echo "::warning::Execute call returned error; packages may not install"
+          started=$(date +%s)
+          scp -o StrictHostKeyChecking=no -P 9122 extra/* admin@localhost:/
+          echo "Uploaded $(find extra -name '*.npk' | wc -l) NPK(s) in $(( $(date +%s) - started ))s (accel=${ARM_ACCEL})."
 
-      - name: Wait for package activation reboot
-        # The execute script runs ~20s then triggers apply-changes (reboot).
-        # Wait for REST to go down, then come back with extra packages active.
+      - name: Reboot CHR and wait for extra packages
+        # Explicit reboot — the CHR installs the uploaded NPKs during boot.
         run: |
           if [ "${ARM_ACCEL}" = "kvm" ]; then
             DOWN_TIMEOUT=3; CURL_TIMEOUT=3; SLEEP_INT=5; REBOOT_TIMEOUT=240
@@ -400,14 +437,28 @@ jobs:
             DOWN_TIMEOUT=15; CURL_TIMEOUT=15; SLEEP_INT=10; REBOOT_TIMEOUT=600
           fi
 
-          echo "Waiting for CHR to go down (execute script takes ~20s before reboot)..."
+          curl -sS -m "$DOWN_TIMEOUT" --fail -X POST http://admin:@localhost:9180/rest/system/reboot \
+            -H 'Content-Type: application/json' > /dev/null 2>&1 || \
+            ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no -p 9122 admin@localhost /system/reboot > /dev/null 2>&1 || true
+
+          # A reboot that never happens is the #96 failure mode: packages stay
+          # listed-but-inactive, every gate downstream still passes, and the crawl
+          # silently loses ~8000 args. Never let this fall through quietly.
+          went_down=0
+          echo "Waiting for CHR to go down after reboot request..."
           for i in $(seq 1 20); do
             if ! curl -sS -m "$DOWN_TIMEOUT" --fail http://localhost:9180/ > /dev/null 2>&1; then
               echo "REST went down after $((i * 3))s."
+              went_down=1
               break
             fi
             sleep 3
           done
+          if [ "$went_down" -ne 1 ]; then
+            echo "::error::CHR never went down after the reboot request — extra packages will NOT be active (see #96)."
+            tail -40 /tmp/qemu.log || true
+            exit 1
+          fi
 
           echo "Waiting for arm64 CHR to restart with extra packages (up to ${REBOOT_TIMEOUT}s, accel=${ARM_ACCEL})..."
           start_time=$(date +%s)
@@ -463,7 +514,8 @@ jobs:
           if [ "${ARM_ACCEL}" = "kvm" ]; then REQ_TIMEOUT=30000; else REQ_TIMEOUT=120000; fi
           bun deep-inspect.ts --live --arch arm64 --output-suffix arm64 \
             --output-dir . --skip-openapi --test-crash-paths --transport rest \
-            --request-timeout "$REQ_TIMEOUT"
+            --request-timeout "$REQ_TIMEOUT" \
+            --require-roots "$REQUIRED_ROOTS"
 
       - name: Verify arm64 deep-inspect output
         run: |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -155,6 +155,45 @@ extra package adds a command would improve docs and downstream search.
 - Runtime and reboot cost are measured before adding CI automation.
 - The output format does not pollute `inspect.json`.
 
+### P2 — Converge `deep-inspect-multi-arch.yaml` onto quickchr
+
+**Why:** the workflow hand-rolls QEMU, package install, licensing and boot-wait
+loops in bash, duplicated per arch, while `scripts/deep-inspect-multi-arch.ts`
+already does all of it through `@tikoci/quickchr` and is the documented local
+path. `nightly.yaml` proves the CI shape works — its arm64 job runs on the same
+`ubuntu-24.04-arm` runner under TCG at free tier and is green (34,735 args,
+21m43s). Keeping two harnesses is what allowed #96 to hide: the two arch jobs had
+drifted onto different package mechanisms and only one rotted. #96 fixed the
+divergence; this removes the duplication that caused it.
+
+**Prerequisites discovered while fixing #96 — get these wrong and it will not boot:**
+
+- Pass `mem: 1024` explicitly. quickchr's `defaultMem()` only returns 1024 for
+  *cross-arch* emulation (`isCrossArchEmulation`), so arm64-on-arm64 gets 512 MB —
+  the exact RAM anti-pattern from the April postmortem. `scripts/nightly-build.ts`
+  already does this; `scripts/deep-inspect-multi-arch.ts` does **not** yet.
+- Install `qemu-utils` on the arm64 runner. quickchr builds per-machine EFI vars
+  with `qemu-img convert` on every aarch64 launch; without it the CHR never boots.
+- Add `bun install --frozen-lockfile`. The workflow has no dependency install step
+  today, and quickchr is a devDependency.
+- Licensing is a **hard fail** in quickchr: `QuickCHR.start()` rethrows every
+  `renewLicense` error as `QuickCHRError` and there is no ignore option. Either
+  start unlicensed and apply `chr.license({account, password, level})` post-boot in
+  a try/catch (one boot, and explicit credentials avoid quickchr's
+  `MIKROTIK_WEB_*` env names), or wait for an upstream `optional`/fallback option
+  in `tikoci/quickchr`.
+- The workflow's `argsTotal >= 30000` floor and the `pathsOnlyB >= 500` diff gate
+  live only in shell; the script has neither. Port them (nightly uses typed
+  helpers, `getArgsTotalFloor`).
+
+**Acceptance criteria:**
+
+- Both arch jobs reduce to install QEMU → probe accel → `bun install` → one script
+  invocation → verify → upload → `quickchr remove --force`.
+- `--require-roots`, `--skip-openapi`, `--test-crash-paths` and `--request-timeout`
+  are all still applied.
+- A green run on a real version with `argsTotal` in the established band per arch.
+
 ## Decision-needed tasks
 
 These are deliberately not implementation-ready until the policy questions are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1098,9 +1098,10 @@ the arm64 job instead fired a `/rest/execute` script ending in
 missed builds (#96). See the anti-pattern below.
 
 ### `/system/package/apply-changes` prompts — never rely on it to reboot
+
 MikroTik's Packages manual documents it as interactive:
 
-```
+```text
 /system/package/apply-changes
 Apply scheduled changes and reboot device? [y/N]:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -964,7 +964,7 @@ half mid-flight, then probes the router — clean queue = &lt;5 s; ghost regress
 | `manual-using-docker-in-docker.yaml` | Manual (`rosver` input) or `auto.yaml` | Installs QEMU, boots CHR, builds base schema, commits to `/docs/{version}/` |
 | `manual-using-extra-docker-in-docker.yaml` | Manual (`rosver` input) or `auto.yaml` | Same as above + installs extra packages, commits to `/docs/{version}/extra/` |
 | `appyamlschemas.yaml` | Manual (`rosver` input) or `auto.yaml` | Boots CHR with extra packages, validates /app YAML schemas (exit codes 0/1/2), commits `app.json` always; commits per-version schemas only on full pass (exit 0); files GitHub issue on exit 2 |
-| `deep-inspect-multi-arch.yaml` | Manual (`rosver` input) or `auto.yaml` | Boots x86 (KVM) and arm64 (KVM preferred, TCG fallback) CHRs with extra packages in parallel, runs live deep-inspect crawl on each, diffs results, publishes `deep-inspect.{x86,arm64}.json` and `diff-deep-inspect.json` to `/docs/{version}/extra/`. Per-arch OpenAPI publication is deferred to `BACKLOG.md` P2. |
+| `deep-inspect-multi-arch.yaml` | Manual (`rosver` input) or `auto.yaml` | Boots x86 (KVM) and arm64 (KVM preferred, TCG fallback) CHRs in parallel. Both arches install extra packages identically — `all_packages-<arch>` zip → SCP → **explicit** reboot — then run a live deep-inspect crawl gated on `--require-roots`, diff results, and publish `deep-inspect.{x86,arm64}.json` and `diff-deep-inspect.json` to `/docs/{version}/extra/`. Per-arch OpenAPI publication is deferred to `BACKLOG.md` P2. |
 | `nightly.yaml` | Daily cron (06:00 UTC) + manual | Discovers the current `mt.lv/nightly-build` (ab) version, boots stable CHRs via quickchr, upgrades them with the nightly NPKs, crawls x86 base + x86 extra + arm64 extra, and publishes the single overwritten `docs/nightly/` slot. Independent of `auto.yaml` so a flaky Box share never blocks stable/beta. Accepts `force` and `nightly_version` dispatch inputs. |
 | `manual-from-secrets.yaml` | Manual | Builds using a real router via GitHub Secrets (no QEMU) |
 | `codeql.yml` | Push + PR + weekly schedule | Runs repository-managed CodeQL for JavaScript/TypeScript and GitHub Actions, using repo path ignores for generated versioned docs artifacts |
@@ -1084,11 +1084,33 @@ instead of being duplicated here. Current decision buckets:
 ## Reference Notes / Known-Broken or Incomplete
 
 ### `deep-inspect-multi-arch.yaml` — ARM64 CI (RESOLVED)
-The arm64 CI job now works under both KVM (when available) and TCG (software
-emulation). Previous failures were caused by **insufficient RAM** (256 MB), not
+The arm64 CI job works under both KVM (when available) and TCG (software
+emulation). The April 2026 failures were caused by **insufficient RAM** (256 MB), not
 TCG being inherently slow. Any workflow that installs all extra packages should
 use 1024 MB RAM. See `docs/deep-inspect.md` for the full postmortem, measured
 baselines, and implementation details.
+
+**Both arches install extra packages the same way** — download
+`all_packages-<arch>-{ver}.zip`, SCP the NPKs to flash root, then issue an
+**explicit** `POST /system/reboot`. Keep it that way. Between April and August 2026
+the arm64 job instead fired a `/rest/execute` script ending in
+`/system/package/apply-changes`; that broke silently and cost three weeks of
+missed builds (#96). See the anti-pattern below.
+
+### `/system/package/apply-changes` prompts — never rely on it to reboot
+MikroTik's Packages manual documents it as interactive:
+
+```
+/system/package/apply-changes
+Apply scheduled changes and reboot device? [y/N]:
+```
+
+The default is **N**. Ending a fire-and-forget REST script on it means the reboot
+may simply never happen — and the failure is invisible: `/system/package` still
+lists every package (they are installed, just inactive), so package-count gates
+pass, and only the crawl notices, thousands of args later. **Trigger package
+activation with an explicit `/system/reboot`, and always assert the CHR actually
+went down.** See #96.
 
 ### Native API `/console/inspect` Completion Non-Determinism
 RouterOS 7.22.1 (and likely all 7.x) returns non-deterministic results for `request=completion`
@@ -1109,9 +1131,12 @@ These rules apply to **all agents working on CI workflows** in this repository:
    takes 10× longer than the measured baseline, the timeout is not the problem. ARM64 TCG on
    x86_64 boots in ~20s, not 600s. See `docs/deep-inspect.md` for measured timing baselines.
 
-2. **Always verify extra packages are actually installed.** After any reboot step that activates
-   packages, `GET /rest/system/package` must show >10 packages. If it shows only `["routeros"]`,
-   the job MUST fail — not continue with base-only output.
+2. **Verify packages are ACTIVE, not merely listed.** `GET /rest/system/package` counts packages
+   that are installed but never activated, so a `>10` count proves nothing — in #96 it returned
+   19 while eight package menus were missing from the tree. Assert on the property you actually
+   care about: the **menus exist**. `deep-inspect.ts --require-roots container,iot,dude,…` fails
+   immediately and names the missing roots (it reads `_meta.census`). Keep the count check as a
+   cheap smoke test, but never as the gate.
 
 3. **Check the output, not just the exit code.** A green CI badge means nothing if the arm64
    file has 577 args instead of 36,023. Add assertions for expected arg counts and diff ranges.
@@ -1125,7 +1150,10 @@ These rules apply to **all agents working on CI workflows** in this repository:
 
 6. **Give QEMU enough RAM.** 256 MB is fine for base RouterOS under KVM, but with 17 extra
    packages under TCG, it causes memory pressure that inflates REST calls from ~70ms to ~10s+.
-   Use 1024 MB for any job that installs extra packages (matches quickchr's default).
+   Use 1024 MB for any job that installs extra packages. Note quickchr only defaults to 1024 MB
+   for **cross-arch** emulation (`defaultMem` → `isCrossArchEmulation`); an arm64 guest on a
+   native arm64 runner gets **512 MB**, so pass `mem: 1024` explicitly as
+   `scripts/nightly-build.ts` does.
    This RAM/REST-stall behaviour is a **separate issue** from the `/console/inspect path=do`
    hang tracked as MikroTik **SUP-127641**. The `do`-path hang on 7.20.8 reproduces identically
    at 128 MB **and** 512 MB (confirmed April 2026 via `bun scripts/test-crash-path-memory.ts`) —
@@ -1140,7 +1168,20 @@ These rules apply to **all agents working on CI workflows** in this repository:
    | aarch64 → aarch64 | KVM/TCG | <5s / ~25s |
    | aarch64 → x86_64 | TCG | >300s — NOT VIABLE |
 
----
+   GitHub's `ubuntu-24.04-arm` runners do **not** expose usable KVM — the accel probe has
+   reported TCG on every observed run, including the green ones. TCG there is fine:
+   `_meta.enrichmentDurationMs` across 19 published arm64 builds is 271–378 s.
+
+8. **A step that can silently do nothing must fail, not warn.** #96 rotted for three weeks
+   because the arm64 "wait for reboot" loop fell through its 60 s window with *no output at
+   all* and the job carried on. If a step's whole purpose is to make something happen, assert
+   that it happened and `exit 1` otherwise. A `::warning::` nobody reads is not a gate.
+
+9. **Never leave two jobs doing the same thing two different ways.** The x86 and arm64 jobs
+   used different package-install mechanisms for four months; only one of them rotted, and the
+   divergence is what hid it. When you debug one arch, do not "temporarily" fork its mechanism —
+   that fork becomes permanent and unvalidated. (In #96 the fork was introduced by `6e1dd58`
+   while the actual bug being chased was RAM, fixed separately by `7052106`.)
 
 ## Environment Variables
 

--- a/deep-inspect.test.ts
+++ b/deep-inspect.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
   filterCompletions,
@@ -831,6 +831,25 @@ describe("CLI: --require-roots census gate", () => {
   test("tolerates leading slashes", async () => {
     const { exitCode } = await runDeepInspect([...baseArgs(), "--require-roots", "/ip,/interface"]);
     expect(exitCode).toBe(0);
+  });
+
+  // Census values are arg COUNTS, and ~10 real roots have zero args (console
+  // verbs like break/continue/exit/quit/undo). A truthiness check would report
+  // those as "missing from the crawled tree" while they are plainly present.
+  test("a root with zero args counts as present, not missing", async () => {
+    const fixture = join(tmpDir, "zero-arg-root.json");
+    writeFileSync(fixture, JSON.stringify({
+      quit: { _type: "cmd" },
+      ip: { _type: "dir", address: { _type: "cmd", numbers: { _type: "arg" } } },
+    }));
+    const { exitCode, stderr } = await runDeepInspect([
+      "--inspect-file", fixture,
+      "--skip-completion", "--skip-openapi",
+      "--output-dir", tmpDir,
+      "--require-roots", "quit,ip",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Required root(s) missing");
   });
 
   test("is opt-in — absent flag never gates", async () => {

--- a/deep-inspect.test.ts
+++ b/deep-inspect.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
   filterCompletions,
@@ -782,6 +782,64 @@ describe("CLI: --request-timeout validation", () => {
 
   test("accepts timeout of 1", async () => {
     const { exitCode } = await runDeepInspect([...baseArgs, "--request-timeout", "1"]);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The gate that would have caught #96 at its source. A package that installs but
+// never activates leaves its whole menu out of the tree while /system/package
+// still counts it, so a package-count gate passes and the argsTotal floor fires
+// thousands of args late naming nothing. --require-roots fails immediately,
+// naming the roots.
+describe("CLI: --require-roots census gate", () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), "restraml-test-")); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  // fixtures/sample-inspect.json roots: certificate convert interface ip system
+  const baseArgs = () => [
+    "--inspect-file", "fixtures/sample-inspect.json",
+    "--skip-completion", "--skip-openapi",
+    "--output-dir", tmpDir,
+  ];
+
+  test("passes when every required root is present", async () => {
+    const { exitCode } = await runDeepInspect([...baseArgs(), "--require-roots", "ip,interface,system"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("exits 2 and names the missing roots", async () => {
+    const { exitCode, stderr } = await runDeepInspect([...baseArgs(), "--require-roots", "ip,container,dude"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("/container");
+    expect(stderr).toContain("/dude");
+    // Present roots must not be reported as missing.
+    expect(stderr).not.toContain("missing from the crawled tree: /ip");
+  });
+
+  test("prints the full census so the shortfall is diagnosable from the log alone", async () => {
+    const { stderr } = await runDeepInspect([...baseArgs(), "--require-roots", "container"]);
+    expect(stderr).toContain("/certificate");
+    expect(stderr).toContain("/system");
+  });
+
+  test("writes no artifact when the gate fails", async () => {
+    await runDeepInspect([...baseArgs(), "--require-roots", "container"]);
+    expect(existsSync(join(tmpDir, "deep-inspect.json"))).toBe(false);
+  });
+
+  test("tolerates leading slashes", async () => {
+    const { exitCode } = await runDeepInspect([...baseArgs(), "--require-roots", "/ip,/interface"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("is opt-in — absent flag never gates", async () => {
+    const { exitCode } = await runDeepInspect(baseArgs());
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty value is treated as no requirement", async () => {
+    const { exitCode } = await runDeepInspect([...baseArgs(), "--require-roots", ""]);
     expect(exitCode).toBe(0);
   });
 });

--- a/deep-inspect.ts
+++ b/deep-inspect.ts
@@ -1120,6 +1120,7 @@ interface CliOptions {
   apiHost?: string;
   apiPort: number;
   requestTimeout?: number;
+  requireRoots: string[];
 }
 
 function parseCliArgs(): { opts: CliOptions; pathArgs: string[] } {
@@ -1141,6 +1142,7 @@ function parseCliArgs(): { opts: CliOptions; pathArgs: string[] } {
       "api-host": { type: "string" },
       "api-port": { type: "string", default: "8728" },
       "request-timeout": { type: "string" },
+      "require-roots": { type: "string" },
     },
     strict: true,
     allowPositionals: true,
@@ -1186,6 +1188,13 @@ function parseCliArgs(): { opts: CliOptions; pathArgs: string[] } {
 
   const requestTimeoutParsed = validatePositiveInteger(values["request-timeout"], "request-timeout", 1);
 
+  // Comma-separated top-level roots that MUST appear in the census. Leading
+  // slashes are tolerated so `--require-roots /container,/iot` also works.
+  const requireRoots = (values["require-roots"] ?? "")
+    .split(",")
+    .map((r) => r.trim().replace(/^\/+/, ""))
+    .filter((r) => r.length > 0);
+
   const [, , ...pathArgs] = positionals;
 
   return {
@@ -1205,6 +1214,7 @@ function parseCliArgs(): { opts: CliOptions; pathArgs: string[] } {
       apiHost: values["api-host"],
       apiPort,
       requestTimeout: requestTimeoutParsed,
+      requireRoots,
     },
     pathArgs,
   };
@@ -1228,6 +1238,11 @@ Options:
   --skip-completion       Skip completion data fetching
   --test-crash-paths      Test CRASH_PATHS for safety (requires live router)
   --request-timeout <ms>  Per-request timeout in ms (e.g. 120000 for slow TCG emulation)
+  --require-roots <list>  Comma-separated top-level roots that must exist in the
+                          census, e.g. "container,iot,dude". Exits 2 naming any
+                          that are missing — catches packages that installed but
+                          never activated (#96). Only pass this when those
+                          packages are expected to be present.
   --transport <mode>      Transport: rest (default), auto, or native
   --api-host <host>       Native API host (default: derived from URLBASE)
   --api-port <port>       Native API port (default: 8728)
@@ -1387,6 +1402,22 @@ async function main() {
     const top3 = Object.entries(census).sort((a, b) => b[1] - a[1]).slice(0, 5)
       .map(([k, v]) => `/${k}=${v}`).join(", ");
     console.log(`Census (top roots): ${top3 || "<empty>"}`);
+  }
+
+  // --require-roots is the gate that catches "packages installed but never
+  // activated" (#96) at its source. A package whose menu never appears leaves a
+  // census key missing, while /system/package still counts it and argsTotal only
+  // sags — so a package-count gate passes and the argsTotal floor fires
+  // thousands of args late, naming nothing. Fail here instead, before enrichment
+  // spends minutes on a tree that is already known-incomplete.
+  const missingRoots = opts.requireRoots.filter((r) => !census[r]);
+  if (missingRoots.length > 0) {
+    console.error(`\n✗ Required root(s) missing from the crawled tree: ${missingRoots.map((r) => `/${r}`).join(" ")}`);
+    console.error("  → Package menus are absent. The usual cause is packages that are installed");
+    console.error("    but never activated — verify the post-upload reboot actually happened (#96).");
+    console.error("  → NOT a schema delta. Do not lower the requirement to make this pass.");
+    console.error(`\n  Census (${Object.keys(census).length} roots): ${Object.keys(census).sort().map((k) => `/${k}`).join(" ")}`);
+    process.exit(2);
   }
 
   // Test CRASH_PATHS (if requested and not already done in --live mode)

--- a/deep-inspect.ts
+++ b/deep-inspect.ts
@@ -1410,7 +1410,10 @@ async function main() {
   // sags — so a package-count gate passes and the argsTotal floor fires
   // thousands of args late, naming nothing. Fail here instead, before enrichment
   // spends minutes on a tree that is already known-incomplete.
-  const missingRoots = opts.requireRoots.filter((r) => !census[r]);
+  // Key presence, not truthiness: a census value is an arg COUNT, and ~10 roots
+  // legitimately have zero args (console verbs like break/continue/exit/quit/undo).
+  // The question here is "did the menu appear at all", not "does it carry args".
+  const missingRoots = opts.requireRoots.filter((r) => !Object.hasOwn(census, r));
   if (missingRoots.length > 0) {
     console.error(`\n✗ Required root(s) missing from the crawled tree: ${missingRoots.map((r) => `/${r}`).join(" ")}`);
     console.error("  → Package menus are absent. The usual cause is packages that are installed");

--- a/docs/deep-inspect.md
+++ b/docs/deep-inspect.md
@@ -172,7 +172,10 @@ default, resolved the failures.
 1. RAM: 256 MB to 1024 MB.
 2. Prefer KVM with TCG fallback instead of KVM-or-bust.
 3. Adaptive timeouts: curl 3s/15s, sleep 5s/10s, boot 120s/300s based on KVM/TCG.
-4. Package install via REST `/execute`, avoiding SCP so both KVM and TCG paths work.
+4. ~~Package install via REST `/execute`, avoiding SCP so both KVM and TCG paths
+   work.~~
+   **Reverted in August 2026 — see the #96 postmortem below.** SCP was never the
+   problem, this change was unnecessary, and it later broke the job for three weeks.
 5. `--request-timeout` of 30s for KVM and 120s for TCG deep-inspect calls.
 
 ### CI anti-patterns learned
@@ -192,7 +195,63 @@ must see them before changing workflows.
    crawl is not `--inspect-file`, `--skip-completion`, or deriving ARM64 output
    from x86.
 6. **Give extra-package jobs enough RAM.** Use 1024 MB for any job that installs
-   all packages.
+   all packages. Note quickchr only defaults to 1024 MB for *cross-arch*
+   emulation; an arm64 guest on a native arm64 runner gets 512 MB, so pass
+   `mem: 1024` explicitly.
+
+## ARM64 package-activation postmortem (#96, August 2026)
+
+The arm64 job failed every run from 2026-07-28 to 2026-08-14 at
+`argsTotal < 30000`, blocking publication of 7.24rc3, 7.23.3 and 7.24rc4.
+
+**Root cause:** the package-activation reboot stopped happening. The signal is a
+line that stops appearing in the `Wait for package activation reboot` step:
+
+| Run | Version | Down-detected | `argsTotal` |
+|---|---|---|---|
+| 30334675878 | 7.24rc2 | `REST went down after 21s.` | 36,793 |
+| 31670987516 | 7.24rc4 | *(none — loop exhausted)* | 28,748 |
+| 31763454996 | 7.23.3 | *(none — loop exhausted)* | short |
+
+Without the reboot the packages stay installed-but-inactive, so `/app`,
+`/caps-man`, `/container`, `/dude`, `/iot`, `/openflow`, `/tr069-client` and
+`/user-manager` never enter the tree — the entire ~8,000-arg shortfall.
+
+**Why it stopped:** the job depended on `/system/package/apply-changes` to
+trigger the reboot, dispatched fire-and-forget through `POST /rest/execute`.
+MikroTik's Packages manual documents `apply-changes` as prompting
+(`Apply scheduled changes and reboot device? [y/N]:`), defaulting to no. The
+workflow file itself was unchanged since May, so this is drift against an
+unchanged fragile script, not a regression we introduced. Also confirmed *not*:
+licensing (7.23.3 failed with a valid fresh trial), the crawl
+(`fetchChild failed for` appears 0x, `argsFailed: 0`), TCG (the last green run
+was also TCG), and upstream RouterOS (local quickchr arm64 at 7.24rc4 is
+identical to 7.24rc2 — 36,793 args, 0 path delta).
+
+**Why the mechanism existed at all:** it was collateral damage. Commit `6e1dd58`
+swapped SCP for `/rest/execute` mid-debugging and deleted the explicit
+`POST /system/reboot` in the same change. SCP was never the failing step — in the
+SCP-era run 24553141540 the steps read `Install extra packages via SCP: success`,
+`Reboot CHR and wait for extra packages: failure`, and that failure was fixed
+three commits later by `7052106` (RAM). The fork survived unvalidated for four
+months.
+
+**Fix:** both arches now use one mechanism — `all_packages-<arch>` zip, SCP to
+flash root, explicit `POST /system/reboot`.
+
+**Why no gate caught it:** the `>=10 packages` check counted 19 *inactive*
+packages and passed; `/system/package` lists packages regardless of activation.
+The `argsTotal >= 30000` floor was the only thing that fired, ~8,000 args late
+and naming nothing. Replaced by `deep-inspect.ts --require-roots`, which reads
+`_meta.census` and fails immediately naming the missing roots. The multi-arch
+workflow requires `container,iot,dude,user-manager,tr069-client,openflow` — all
+six are present in every published versioned artifact back to 7.20.8 on both
+arches. Nightly deliberately does not use this list: its NPK set carries no
+`dude`, `openflow`, `tr069-client` or `user-manager` (see `absentRoots`).
+
+`diff-deep-inspect.ts` additionally reports root-menu drift between the two
+arches. That one is report-only — `/blink` and `/zerotier` are legitimately
+arm64-only.
 
 ### Boot timing reference
 

--- a/scripts/deep-inspect-multi-arch.ts
+++ b/scripts/deep-inspect-multi-arch.ts
@@ -38,7 +38,7 @@
 
 import { parseArgs } from "node:util";
 import { QuickCHR, type Arch, type Channel } from "@tikoci/quickchr";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 // ── CLI ────────────────────────────────────────────────────────────────────
@@ -49,6 +49,7 @@ interface Opts {
   version?: string;
   outputDir: string;
   keepRunning: boolean;
+  requireRoots: string;
 }
 
 function parseCli(): Opts {
@@ -60,6 +61,10 @@ function parseCli(): Opts {
       version: { type: "string" },
       "output-dir": { type: "string", default: "." },
       "keep-running": { type: "boolean", default: false },
+      // Mirrors the REQUIRED_ROOTS env in deep-inspect-multi-arch.yaml. This
+      // script always starts CHRs with installAllPackages, so all six menus are
+      // expected; a missing one means the packages never activated (#96).
+      "require-roots": { type: "string", default: "container,iot,dude,user-manager,tr069-client,openflow" },
       help: { type: "boolean", default: false },
     },
     strict: true,
@@ -91,6 +96,7 @@ function parseCli(): Opts {
     version: values.version,
     outputDir: values["output-dir"] ?? ".",
     keepRunning: values["keep-running"] ?? false,
+    requireRoots: values["require-roots"] ?? "",
   };
 }
 
@@ -107,6 +113,9 @@ Options:
   --version <ver>      Specific RouterOS version (overrides --channel)
   --output-dir <dir>   Where to write deep-inspect.<arch>.json (default: .)
   --keep-running       Leave CHRs running after crawl (for post-mortem)
+  --require-roots <l>  Comma-separated roots that must exist in the census
+                       (default: container,iot,dude,user-manager,tr069-client,openflow).
+                       Pass "" to disable. See #96.
   --help               Show this help
 
 Output files (one per arch):
@@ -203,6 +212,7 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
     opts.outputDir,
     "--transport",
     "rest",
+    ...(opts.requireRoots ? ["--require-roots", opts.requireRoots] : []),
   ];
 
   console.log(`\nRunning: bun ${deepInspectArgs.join(" ")}`);
@@ -227,6 +237,18 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
     console.warn(`⚠ ${arch}: deep-inspect.ts exited 2 (crawl incomplete) — reading _meta for diagnostics before cleanup.`);
   }
 
+  // --require-roots exits 2 *before* the artifact is written (the tree is known
+  // bad, so there is nothing worth writing). Everything the operator needs is
+  // already on stderr, so surface that rather than an ENOENT from readFileSync.
+  const deepInspectPath = join(opts.outputDir, `deep-inspect.${arch}.json`);
+  if (exitCode === 2 && !existsSync(deepInspectPath)) {
+    if (!opts.keepRunning) await chr.destroy();
+    throw new Error(
+      `${arch}: deep-inspect.ts exited 2 without writing ${deepInspectPath} — ` +
+      "required package roots were missing from the crawled tree (see the census above, #96).",
+    );
+  }
+
   // Post-crawl load snapshot (best-effort) — informational, not load-bearing.
   // Proof-of-life for queryLoad(); the real retry/load correlation work wants
   // in-crawl sampling — a future improvement, not yet scheduled.
@@ -236,7 +258,6 @@ async function runArch(arch: Arch, opts: Opts): Promise<ArchResult> {
   }
 
   // Read the output file and extract _meta to check for anomalies.
-  const deepInspectPath = join(opts.outputDir, `deep-inspect.${arch}.json`);
   const deepInspect = JSON.parse(readFileSync(deepInspectPath, "utf-8")) as {
     _meta: {
       version: string;

--- a/scripts/diff-deep-inspect.ts
+++ b/scripts/diff-deep-inspect.ts
@@ -61,6 +61,7 @@ interface DeepInspect {
       argsTimedOut: number;
       argsBlankOnRetry: number;
     };
+    census?: Record<string, number>;
   };
   [key: string]: unknown;
 }
@@ -88,6 +89,15 @@ interface TypeMismatch {
   bType: NodeType | undefined;
 }
 
+/** Top-level roots present in one file and absent in the other.
+ *  Report-only: some asymmetry is legitimate (/blink is arm64-only, and the
+ *  nightly NPK set carries no dude/openflow/tr069-client/user-manager). It is
+ *  still the fastest way to see a whole package menu go missing (#96). */
+interface CensusDrift {
+  onlyInA: string[];
+  onlyInB: string[];
+}
+
 interface DiffReport {
   a: { label: string; path: string; meta: DeepInspect["_meta"] };
   b: { label: string; path: string; meta: DeepInspect["_meta"] };
@@ -110,6 +120,7 @@ interface DiffReport {
   completionDrift: CompletionDrift[];
   completionPayloadDrift: CompletionPayloadDrift[];
   typeMismatches: TypeMismatch[];
+  censusDrift: CensusDrift;
 }
 
 function completionPayloadFieldDrift(a: CompletionEntry, b: CompletionEntry): string[] {
@@ -300,6 +311,19 @@ function diff(
 
   const pathsBoth = [...mapA.keys()].filter((k) => mapB.has(k)).length;
 
+  // Fall back to the tree's own top-level keys when _meta.census is absent —
+  // artifacts published before #97 have no census but the roots are still there.
+  const rootsOf = (d: DeepInspect): string[] =>
+    d._meta.census
+      ? Object.keys(d._meta.census)
+      : Object.keys(d).filter((k) => !k.startsWith("_"));
+  const rootsA = new Set(rootsOf(a));
+  const rootsB = new Set(rootsOf(b));
+  const censusDrift: CensusDrift = {
+    onlyInA: [...rootsA].filter((r) => !rootsB.has(r)).sort(),
+    onlyInB: [...rootsB].filter((r) => !rootsA.has(r)).sort(),
+  };
+
   return {
     a: { label: aLabel, path: aPath, meta: a._meta },
     b: { label: bLabel, path: bPath, meta: b._meta },
@@ -322,6 +346,7 @@ function diff(
     completionDrift,
     completionPayloadDrift,
     typeMismatches,
+    censusDrift,
   };
 }
 
@@ -372,6 +397,18 @@ function textReport(r: DiffReport, opts: Opts): string {
   lines.push(`  completion payload drift: ${c.completionPayloadDrift} arg(s) with shared keys but differing style/preference/desc`);
   lines.push(`  type mismatches : ${c.typeMismatches}`);
   lines.push("");
+
+  const cd = r.censusDrift;
+  if (cd.onlyInA.length > 0 || cd.onlyInB.length > 0) {
+    lines.push("━━━ Root Menu Drift ━━━");
+    lines.push("  (whole top-level menus present on one side only — report, not a verdict)");
+    if (cd.onlyInA.length > 0) lines.push(`    only in ${A}: ${cd.onlyInA.map((x) => `/${x}`).join(" ")}`);
+    if (cd.onlyInB.length > 0) lines.push(`    only in ${B}: ${cd.onlyInB.map((x) => `/${x}`).join(" ")}`);
+    lines.push("  Some asymmetry is legitimate (/blink is arm64-only; the nightly NPK set");
+    lines.push("  carries no dude/openflow/tr069-client/user-manager). But a package menu");
+    lines.push("  missing on one arch only usually means its packages never activated (#96).");
+    lines.push("");
+  }
 
   if (c.typeMismatches > 0) {
     lines.push("━━━ Type Mismatches ━━━");


### PR DESCRIPTION
Fixes the arm64 `deep-inspect` job, which has failed **every run since 2026-07-28**, blocking publication of 7.24rc3, 7.23.3 and 7.24rc4. Full investigation in #96.

## Root cause

The package-activation reboot stopped happening. The tell is a line that stops appearing in the reboot step:

| Run | Version | Down-detected? | `argsTotal` |
|---|---|---|---|
| [30334675878](https://github.com/tikoci/restraml/actions/runs/30334675878) | 7.24rc2 | `REST went down after 21s.` | **36,793** ✅ |
| [31670987516](https://github.com/tikoci/restraml/actions/runs/31670987516) | 7.24rc4 | *(loop exhausted, no output)* | 28,748 ❌ |
| [31763454996](https://github.com/tikoci/restraml/actions/runs/31763454996) | 7.23.3 | *(loop exhausted, no output)* | short ❌ |

Without the reboot the packages stay installed-but-inactive, so `/app`, `/caps-man`, `/container`, `/dude`, `/iot`, `/openflow`, `/tr069-client` and `/user-manager` never enter the tree — the entire ~8,000-arg shortfall.

The job depended on `/system/package/apply-changes` to trigger that reboot, dispatched fire-and-forget through `POST /rest/execute`. MikroTik documents `apply-changes` as **prompting**:

```
Apply scheduled changes and reboot device? [y/N]:
```

Default is **N**. The workflow file was unchanged since May, so this is drift against a fragile script, not a regression we introduced — which is also why 7.23.3, a version that used to build fine, now fails too.

**Not** licensing (7.23.3 failed with a fresh valid trial), **not** the crawl (`fetchChild failed for` appears 0×, `argsFailed: 0`), **not** TCG (the last green run was also TCG), **not** upstream (local quickchr arm64 at 7.24rc4 is identical to 7.24rc2 — 36,793 args, 0 path delta).

## Why this is a revert

The arm64 job originally used the same SCP path as x86. `6e1dd58` swapped it for `/rest/execute` mid-debugging and deleted the explicit `POST /system/reboot` in the same commit. SCP was never the failing step — in run [24553141540](https://github.com/tikoci/restraml/actions/runs/24553141540) the steps read `Install extra packages via SCP: success`, `Reboot CHR and wait for extra packages: failure`, and that failure was fixed three commits later by `7052106` (RAM 256 → 1024 MB). The fork survived unvalidated for four months.

## Changes

- **Both arches install packages identically** — `all_packages-<arch>` zip → SCP to flash root → **explicit** `POST /system/reboot`.
- **The reboot can no longer fail silently**, on either arch. An expired down-loop is now `::error::` + `exit 1` instead of silence (arm64) or an unread `::warning::` (x86). This is what let the bug rot for three weeks.
- **`deep-inspect.ts --require-roots`** asserts package menus exist in `_meta.census` and exits 2 naming any missing. The `>=10 packages` gate could not see this failure — it counted 19 *inactive* packages and passed, while the `argsTotal` floor fired ~8,000 args late naming nothing.
- **Cross-arch root-menu drift** reported by `diff-deep-inspect.ts`. Report-only — `/blink` and `/zerotier` are legitimately arm64-only.
- **License failures are actually detected.** `/system/license/renew` answers HTTP 200 for both outcomes, so `curl && echo` printed *"License activated"* even on `ERROR: Licensing Error: too many trial licences`. Now parses the body, warns, keeps running free-tier (still correct, just slower), and raises one standing issue — created once, no daily comment spam, since an exhausted trial pool is a persistent condition rather than an episodic one.

## Grounding

- **Required-roots list validated against every published artifact**: all six present in all 40 versioned `deep-inspect.*.json` files back to 7.20.8, on both arches. Only nightly lacks them — exactly its four documented `absentRoots` — so nightly deliberately opts out.
- **SCP sizing is not a guess.** `nightly.yaml` pushes a comparable **52.0 MiB** of NPKs to an arm64 TCG CHR at 1024 MB and completes upload+reboot+boot in **~64 s**. The 52-*minute* SCP seen in April was the 256 MB memory-pressure artifact. A 15-minute step bound is added so a return of that pressure fails fast instead of consuming the job budget.

## Testing

`bun run lint`, `bun run typecheck`, `bun run lint:workflows` clean. `bun test`: **235 pass, 0 fail** (7 new tests covering the roots gate — exit code, named roots, census printed, no artifact written, slash tolerance, opt-in behavior).

The end-to-end proof is necessarily a CI dispatch. After merge, dispatch `deep-inspect-multi-arch.yaml` for `7.24rc4` and confirm `Install extra packages via SCP` succeeds, `REST went down after …s.` is present, and `argsTotal` lands in the ~36.8k band — then backfill `7.24rc3` and `7.23.3`.

## Out of scope

quickchr convergence — still the right direction (nightly's arm64 job is green on the same runner), but a larger change. Filed in `BACKLOG.md` as P2 with the three prerequisites this investigation surfaced, notably that quickchr only defaults to 1024 MB for *cross-arch* emulation, so a native ARM runner would silently get 512 MB.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional required-root validation for deep inspections, with clear diagnostics when expected menus are missing.
  - Added root-menu drift reporting to deep-inspection comparisons.
  - Added automated trial-license activation and degradation reporting for multi-architecture checks.

- **Bug Fixes**
  - Improved ARM64 package installation and reboot handling, including failure diagnostics and architecture-specific timeouts.
  - Prevented workflows from continuing when required validation artifacts are unavailable.

- **Documentation**
  - Expanded deep-inspection CI guidance, troubleshooting details, and migration backlog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->