### PR TITLE
Fix diff.html changelog recursion (N5 regression) + nightly CodeQL

### DIFF
--- a/docs/deep-inspect.future.schema.json
+++ b/docs/deep-inspect.future.schema.json
@@ -69,6 +69,12 @@
         "completionStats": {
           "$ref": "#/definitions/completionStats"
         },
+        "crawlStats": {
+          "$ref": "#/definitions/crawlStats"
+        },
+        "census": {
+          "$ref": "#/definitions/census"
+        },
         "nativeApiReconnects": {
           "$ref": "#/definitions/nativeApiReconnects"
         },
@@ -114,6 +120,31 @@
         }
       },
       "additionalProperties": false
+    },
+    "crawlStats": {
+      "type": "object",
+      "description": "Crawl-stage observability (see #96). Non-zero pathsFailed means subtrees were silently dropped previously — now surfaced. Max 50 failedPaths stored.",
+      "required": ["pathsFailed", "failedPaths"],
+      "properties": {
+        "pathsFailed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedPaths": {
+          "type": "array",
+          "maxItems": 50,
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "census": {
+      "type": "object",
+      "description": "Per top-level root arg count census (e.g. {\"ip\": 4231}). Lets a total shortfall point at which subtree vanished. Derived from crawled tree before enrichment.",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
     },
     "nativeApiReconnects": {
       "type": "object",

--- a/docs/diff.html
+++ b/docs/diff.html
@@ -634,8 +634,10 @@
                 : `Every release note section after ${range.older} up to ${range.newer}, so the API diff has human upgrade context.`
         }
 
-        function getChangelogVersionsInRange(range) {
-            // Use shared helper which always excludes synthetic nightly (no CHANGELOG on download.mikrotik.com)
+        function getDiffChangelogVersionsInRange(range) {
+            // Delegate to shared helper which always excludes synthetic nightly (no CHANGELOG on download.mikrotik.com)
+            // Use window.* to reach the shared implementation from restraml-shared.js;
+            // this wrapper is named differently to avoid shadowing that global.
             if (typeof window.getChangelogVersionsInRange === 'function') {
                 // Shared helper is available (N5) — it already excludes nightly
                 return window.getChangelogVersionsInRange(range, _diffVersions, _diffShowAll)
@@ -716,9 +718,10 @@
             }
         }
 
-        async function fetchChangelogSectionsForVersion(version) {
+        async function fetchDiffChangelogSectionsForVersion(version) {
             if (isNightly(version)) {
                 // Synthetic section from nightly.json — shared helper handles caching
+                // Use window.* to reach the shared implementation; this wrapper is renamed to avoid shadowing it.
                 if (typeof window.fetchChangelogSectionsForVersion === 'function') {
                     return window.fetchChangelogSectionsForVersion(version)
                 }
@@ -772,7 +775,7 @@
             changelogRangeCount.textContent = ''
 
             try {
-                const versions = getChangelogVersionsInRange(range)
+                const versions = getDiffChangelogVersionsInRange(range)
                 // Synthetic nightly section when the range touches the nightly slot
                 let nightlySections = []
                 if (isNightly(range.newer) || isNightly(range.older)) {
@@ -784,7 +787,7 @@
                 }
                 const sectionGroups = await Promise.all(
                     versions.map(async version => {
-                        const sections = await fetchChangelogSectionsForVersion(version)
+                        const sections = await fetchDiffChangelogSectionsForVersion(version)
                         const matchingSections = sections.filter(section => section.version === version)
                         const selectedSections = matchingSections.length > 0
                             ? matchingSections

--- a/scripts/nightly-build.test.ts
+++ b/scripts/nightly-build.test.ts
@@ -6,6 +6,7 @@ import {
   getArgsTotalFloor,
   getExpectedMinPackageCount,
   getNpksForPhase,
+  isSafeNpkFilename,
   parseAb,
 } from "./nightly-build.ts";
 
@@ -172,5 +173,48 @@ describe("phase-aware helpers (N3.5 — per-phase gates)", () => {
     const expectedBase = `deep-inspect.${baseSuffix}.json`;
     const deepFileBase = outsOnlyExtra.includes(expectedBase) ? expectedBase : undefined;
     expect(deepFileBase).toBeUndefined();
+  });
+});
+
+describe("isSafeNpkFilename — CodeQL js/http-to-file-access guard (PR #102)", () => {
+  test("accepts valid NPK basenames from real Box fixture", () => {
+    // Every file in the real fixture is a valid basename — the guard must not reject them.
+    for (const f of allFiles.filter((n) => n.endsWith(".npk"))) {
+      expect(isSafeNpkFilename(f)).toBe(true);
+    }
+    expect(isSafeNpkFilename("routeros-x86-7.25_ab434.npk")).toBe(true);
+    expect(isSafeNpkFilename("container-7.25_ab434.npk")).toBe(true);
+    expect(isSafeNpkFilename("wireless-7.25_ab434-arm64.npk")).toBe(true);
+    expect(isSafeNpkFilename("my-file_123.npk")).toBe(true);
+    expect(isSafeNpkFilename("a1_B2-C3.npk")).toBe(true);
+  });
+
+  test("rejects path separators and traversal", () => {
+    expect(isSafeNpkFilename("a/b.npk")).toBe(false);
+    expect(isSafeNpkFilename("a\\b.npk")).toBe(false);
+    expect(isSafeNpkFilename("../evil.npk")).toBe(false);
+    expect(isSafeNpkFilename("..\\evil.npk")).toBe(false);
+    expect(isSafeNpkFilename("../../etc/passwd")).toBe(false);
+    expect(isSafeNpkFilename("dir/../routeros.npk")).toBe(false);
+    expect(isSafeNpkFilename("/absolute.npk")).toBe(false);
+  });
+
+  test("rejects invalid characters, wrong extensions, and empty", () => {
+    expect(isSafeNpkFilename("bad name.npk")).toBe(false); // space
+    expect(isSafeNpkFilename("bad$name.npk")).toBe(false);
+    expect(isSafeNpkFilename("file.txt")).toBe(false);
+    expect(isSafeNpkFilename("file.npk.exe")).toBe(false);
+    expect(isSafeNpkFilename("file")).toBe(false);
+    expect(isSafeNpkFilename("")).toBe(false);
+    expect(isSafeNpkFilename(".npk")).toBe(false); // no basename
+    expect(isSafeNpkFilename("a/b\\c..npk")).toBe(false);
+  });
+
+  test("filterNpksByArch output is always safe", () => {
+    const x86 = filterNpksByArch(allFiles, VER, "x86");
+    const arm64 = filterNpksByArch(allFiles, VER, "arm64");
+    for (const f of [...x86, ...arm64]) {
+      expect(isSafeNpkFilename(f)).toBe(true);
+    }
   });
 });

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -180,6 +180,13 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)} MiB`;
 }
 
+export function isSafeNpkFilename(file: string): boolean {
+  // Guard Box-derived file names before they reach the file system.
+  // Reject path separators, traversal segments, and anything outside the
+  // expected NPK basename charset; empty and wrong-extension values fail the regex.
+  return !file.includes("/") && !file.includes("\\") && !file.includes("..") && /^[A-Za-z0-9._-]+\.npk$/.test(file);
+}
+
 // ── Nightly discovery (arch-aware) ───────────────────────────────────────────
 
 export function filterNpksByArch(files: string[], nightlyVer: string, arch: Arch): string[] {
@@ -337,8 +344,7 @@ async function downloadNpks(files: string[], dir: string, token: string) {
   mkdirSync(dir, { recursive: true });
   log(`→ downloading ${files.length} NPKs to ${dir}`);
   for (const file of files) {
-    // Validate file name from Box API — prevent path traversal via crafted file_name
-    if (file.includes("/") || file.includes("\\") || file.includes("..") || !/^[A-Za-z0-9._-]+\.npk$/.test(file)) {
+    if (!isSafeNpkFilename(file)) {
       fail(`Refusing to download unsafe file name "${file}"`);
     }
     const url = boxDlUrl(token, file);
@@ -628,7 +634,7 @@ async function main() {
     // Validate network-derived nightlyVer before writing provenance (sanitizer for CodeQL)
     if (!parseAb(nightlyVer)) fail(`Invalid nightly version "${nightlyVer}" for provenance`);
     try {
-      // lgtm[js/http-to-file-access] -- provenance is validated Box metadata, path is fixed mkdtemp/nightly.json
+      // lgtm[js/http-to-file-access] -- nightlyVer is validated Box metadata (parseAb); only nightly.json basename is fixed, parent directory is from configured --output-dir / mkdtemp
       writeFileSync(join(tmpDir, "nightly.json"), JSON.stringify(nightlyProvenance, null, 2) + "\n");
       log(`  provenance → ${join(tmpDir, "nightly.json")}`);
     } catch (e) {

--- a/scripts/nightly-build.ts
+++ b/scripts/nightly-build.ts
@@ -337,6 +337,10 @@ async function downloadNpks(files: string[], dir: string, token: string) {
   mkdirSync(dir, { recursive: true });
   log(`→ downloading ${files.length} NPKs to ${dir}`);
   for (const file of files) {
+    // Validate file name from Box API — prevent path traversal via crafted file_name
+    if (file.includes("/") || file.includes("\\") || file.includes("..") || !/^[A-Za-z0-9._-]+\.npk$/.test(file)) {
+      fail(`Refusing to download unsafe file name "${file}"`);
+    }
     const url = boxDlUrl(token, file);
     const dest = join(dir, file);
     if (existsSync(dest)) {
@@ -621,7 +625,10 @@ async function main() {
       // Roots nightly can never supply (Box share has no NPKs for these) — see #90 §1.2
       absentRoots: ["dude", "openflow", "tr069-client", "user-manager"],
     };
+    // Validate network-derived nightlyVer before writing provenance (sanitizer for CodeQL)
+    if (!parseAb(nightlyVer)) fail(`Invalid nightly version "${nightlyVer}" for provenance`);
     try {
+      // lgtm[js/http-to-file-access] -- provenance is validated Box metadata, path is fixed mkdtemp/nightly.json
       writeFileSync(join(tmpDir, "nightly.json"), JSON.stringify(nightlyProvenance, null, 2) + "\n");
       log(`  provenance → ${join(tmpDir, "nightly.json")}`);
     } catch (e) {


### PR DESCRIPTION
### What broke

After **N5 (#98)** the diff tool's **Show CHANGELOGs** panel always fell back to *The release notes could not be loaded inline* (e.g. https://tikoci.github.io/restraml/diff.html?compare1=7.21.3&compare2=7.23.2&extra=false&testing=true&nightly=true&format=line-by-line&hunks=hiding&changelog=open). The link itself works, but inline never renders — even for old versions. A new screenshot also shows `RangeError: Maximum call stack size exceeded` at `getChangelogVersionsInRange` (diff.html:637 → 641 repeating).

### Root cause — shadowing recursion

`docs/diff.html` N5 added two wrappers that delegate to the shared helpers from `restraml-shared.js`:

```js
function getChangelogVersionsInRange(range) {
  if (typeof window.getChangelogVersionsInRange === 'function')
    return window.getChangelogVersionsInRange(range, _diffVersions, _diffShowAll)
  // fallback…
}
```

`restraml-shared.js` already assigns `window.getChangelogVersionsInRange = shared`. The inline `<script>`'s function declaration then **shadows** that global — `window.getChangelogVersionsInRange` becomes the local wrapper itself — so the `if` is always true and the call recurses infinitely. Same pattern for `fetchChangelogSectionsForVersion`.

The failure is deterministic for any range; nightly was a red herring.

### Fix — this PR

* **`docs/diff.html`** — rename the diff wrappers to `getDiffChangelogVersionsInRange` / `fetchDiffChangelogSectionsForVersion` and update the single call sites (`loadRangeChangelog`). `window.getChangelogVersionsInRange` / `window.fetchChangelogSectionsForVersion` now unambiguously refer to the shared implementation; the local fallback only runs when the shared helper is absent (stale cache). The stack-overflow and inline failure are gone.

* **`scripts/nightly-build.ts` — CodeQL `js/http-to-file-access` (652).** Validate Box-derived NPK file names against `^[A-Za-z0-9._-]+\.npk$` and reject `/`, `\\`, `..` before `Bun.write`. Validate `nightlyVer` via `parseAb` before writing provenance and annotate the fixed-path `writeFileSync(join(tmpDir, "nightly.json"))` with `lgtm[js/http-to-file-access]` (path is `mkdtemp/nightly.json`, content is validated Box metadata). No behavior change; just a sanitizer + suppression so the alert closes.

* **`docs/deep-inspect.future.schema.json`** — add `crawlStats` + `census` to the future meta so it remains a **superset** of current artifacts. `7.24rc4` (published after N5) now emits those fields via `deep-inspect.ts`; without them `bun test` (deep-inspect-schema) fails with `_meta must NOT have additional properties` / `crawlStats`,`census`. Mirrors the current schema definitions verbatim. This is the same fix that would be needed on `main` regardless of this PR.

### Also checked

* GitHub Security → Code Quality → `js/automatic-semicolon-insertion` link in #90 was inspected. No open `automatic-semicolon-insertion` alert exists in CodeQL on `main` (`gh api code-scanning/alerts` shows 8 unique rules, none is that ID); `biome check` + `tsc` are clean, and the diff.html change adds no new ASI-sensitive lines. If a quality finding appears on the PR, it will be addressed — the current fix does not introduce ASI risk.

### Verification

* `bun test` — 236 pass (was 235 pass + 1 fail on main due to future-schema mismatch; now green).
* `bun run lint` — `biome 0`, `tsc 0`, `actionlint 9 pass`.
* Manual logic check: the renamed wrappers correctly delegate to `window.*` shared helpers; the old names would still recurse (reproduced via a minimal `window` shim).

Refs #90, #98. Fixes the regression noted in https://github.com/tikoci/restraml/issues/90#issuecomment-5289449650 and the console `Maximum call stack size exceeded` trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded deep inspection results with crawl statistics, including failed paths.
  * Added census data showing counts for top-level roots.

* **Bug Fixes**
  * Improved validation of nightly build metadata and downloaded package names.
  * Prevented invalid or unsafe package paths from being processed.

* **Documentation**
  * Updated the inspection schema to document the new metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->